### PR TITLE
Wrong borrow on multi-operand subtraction #12

### DIFF
--- a/libs/calc-arithmetic/src/lib/positional/subtraction.spec.ts
+++ b/libs/calc-arithmetic/src/lib/positional/subtraction.spec.ts
@@ -1,8 +1,9 @@
 import { SubtractionOperand, SubtractionPositionResult, SubtractionResult } from '../models';
-import { subtractDigitArrays, subtractDigitsAtPosition } from './subtraction';
+import { subtractDigitArrays, subtractDigitsAtPosition, subtractPositionalNumbers } from './subtraction';
+import { fromNumber } from '@calc/calc-arithmetic';
 
 describe('subtraction', () => {
-    describe('#addDigitsAtPosition', () => {
+    describe('#subtractDigitsAtPosition', () => {
         it('should return proper result when subtracting smaller number from greater', () => {
             // given
             const base = 10;
@@ -292,4 +293,35 @@ describe('subtraction', () => {
             });
         });
     });
+
+    describe('#subtractPositionalNumbers', () => {
+        describe('when subtracting multiple operands', () => {
+            it('should return result with proper borrow chain when borrow amount is greater than 1', () => {
+                // given
+                const x = fromNumber(10, 10).result;
+                const y = fromNumber(9, 10).result;
+                const z = fromNumber(2, 10).result;
+
+                // when
+                const result = subtractPositionalNumbers([x, y, z]);
+
+                // then
+                const expected: SubtractionOperand []= [
+                    {
+                        base: 10,
+                        position: 0,
+                        representationInBase: '0',
+                        valueInDecimal: 0
+                    },
+                    {
+                        base: 10,
+                        position: 0,
+                        representationInBase: '20',
+                        valueInDecimal: 20
+                    }
+                ];
+                expect(result.positionResults[0].operands[0].borrowChain).toEqual(expected);
+            })
+        })
+    })
 });

--- a/libs/calc-arithmetic/src/lib/positional/subtraction.ts
+++ b/libs/calc-arithmetic/src/lib/positional/subtraction.ts
@@ -151,7 +151,9 @@ function borrowToSource(base: number, borrow: Borrow, lookupMinuend: Record<numb
     const beforeBorrow: Digit = { ...lookupMinuend[sourcePosition] };
     const valueBeforeBorrow = beforeBorrow.valueInDecimal;
 
-    const valueAfterBorrow = valueBeforeBorrow + (amount * Math.pow(base, amount));
+    const positionDifference = fromPosition - sourcePosition;
+
+    const valueAfterBorrow = valueBeforeBorrow + (amount * Math.pow(base, positionDifference));
     const representationAfterBorrow = fromNumber(valueAfterBorrow, base).result.toString();
 
     const afterBorrow: Digit = {

--- a/libs/grid/src/lib/core/subtraction-grid.tsx
+++ b/libs/grid/src/lib/core/subtraction-grid.tsx
@@ -5,7 +5,8 @@ import { buildAxis } from './axis-utils';
 import { getGridLines } from './grid-line-utils';
 import { HoverOperationGrid } from '../models/hover-operation-grid';
 import {
-    buildColumnGroups, buildEmptyGrid, DigitsInfo,
+    buildColumnGroups,
+    buildEmptyGrid,
     digitsToCellConfig,
     extractResultMeta,
     operandDigitsToCellConfig,

--- a/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
+++ b/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
@@ -63,13 +63,13 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange }) => {
     const [operation, setOperation] = useState<Operation>(allOperations[1]);
     const [algorithm, setAlgorithm] = useState<OperationAlgorithm>(subtractionAlgorithms[0]);
     const [operands, setOperands] = useState<ValidatedOperand[]>(
-        [{valid: true, representation: '25 15'}, {valid: true, representation: '19'}]
+        [{valid: true, representation: '10'}, {valid: true, representation: '9'}, {valid: true, representation: '2'}]
     );
     const [canAddOperand] = useState(true);
     const [canCalculate, setCanCalculate] = useState(false);
 
     const initialValues: FormValues = {
-        base: 64,
+        base: 10,
         representation: '0.0',
         operands: []
     };

--- a/libs/positional-calculator/src/lib/positional-calculator-view/positional-calculator-view.tsx
+++ b/libs/positional-calculator/src/lib/positional-calculator-view/positional-calculator-view.tsx
@@ -46,14 +46,14 @@ export const PositionalCalculatorView: FC = () => {
     const classes = useStyles();
     const [currentTab, setCurrentTab] = useState(0);
     const [operation, setOperation] = useState<OperationType>(OperationType.Addition);
-
-    const handleChange = (event: React.ChangeEvent<{}>, newValue: number) => {
-        setCurrentTab(newValue);
-    };
     const { t } = useTranslation();
     const [res, setRes] = useState<GridResult | undefined>();
     const [params, setParams] = useState<OperationParams<AlgorithmType>>();
     const gridId = 'calculator-grid';
+
+    const handleChange = (event: React.ChangeEvent<{}>, newValue: number) => {
+        setCurrentTab(newValue);
+    };
 
     const onSubmit = function <T extends AlgorithmType>(
         base: number,

--- a/libs/positional-calculator/src/lib/subtraction/subtraction-position-result/subtraction-position-result.tsx
+++ b/libs/positional-calculator/src/lib/subtraction/subtraction-position-result/subtraction-position-result.tsx
@@ -7,6 +7,7 @@ interface P {
 }
 
 export const SubtractAtPositionResult: FC<P> = ({positionResult}) => {
+    console.log(positionResult);
     const operands = positionResult.operands.map((operand, index) => {
         const rep = operand.borrowChain
             ? operand.borrowChain[operand.borrowChain.length -1]


### PR DESCRIPTION
- fix borrow chain when borrow amount is greater than 1
- rc of that was in borrowToSource function, the position-based
  value of borrow was calculated using amount in pow instead
  of position difference

closes #12 