### PR TITLE
B64 addition bugs:

### DIFF
--- a/libs/calc-arithmetic/src/lib/helpers/conversion-helpers.spec.ts
+++ b/libs/calc-arithmetic/src/lib/helpers/conversion-helpers.spec.ts
@@ -8,7 +8,7 @@ import {
     isFloatingPointStr,
     isValidString,
     removeZeroDigits,
-    representationStrToStrArray,
+    representationStrToStrArray, serializeRepresentationStr,
     splitToDigits, splitToDigitsList,
     splitToPartsArr
 } from './conversion-helpers';
@@ -387,6 +387,31 @@ describe('conversion-helpers', () => {
             expect(arbitraryIntegralToDecimal(input, base)).toEqual(expected);
         });
 
+        it('converts positive number in base 64 to base 64', () => {
+            // given
+            const input = '32 18';
+            const base = 64;
+            const expected = new BigNumber(2066);
+
+            // when
+            expect(arbitraryIntegralToDecimal(input, base)).toEqual(expected);
+        });
+
+        it('converts negative number in base 64 to base 64', () => {
+            // given
+            const input = '-32 18';
+            const base = 64;
+            const expected = new BigNumber(-2066);
+
+            // when
+            const result = arbitraryIntegralToDecimal(input, base);
+            console.log(result);
+
+            // when
+            expect(result).toEqual(expected);
+        });
+
+
         it('throws error if repStr does match input base', () => {
             // given
             const input = 'FF8';
@@ -731,6 +756,20 @@ describe('conversion-helpers', () => {
                     valueInDecimal: 5
                 }
             ];
+            expect(result).toEqual(expected)
+        });
+    });
+
+    describe('serializeRepresentationStr tests', () => {
+        it('should replace invalid signs, delimiters and whitespace with valid', () => {
+            // given
+           const representation = '−12 45,34  56  ';
+
+            // when
+            const result = serializeRepresentationStr(representation);
+
+            // then
+            const expected = '-12 45.34 56';
             expect(result).toEqual(expected)
         });
     });

--- a/libs/calc-arithmetic/src/lib/helpers/conversion-helpers.ts
+++ b/libs/calc-arithmetic/src/lib/helpers/conversion-helpers.ts
@@ -97,17 +97,18 @@ export function arbitraryIntegralToDecimal(
     base: number
 ): BigNumber {
     if (isValidString(repStr, base)) {
+        let rep = repStr.trim();
         let result = new BigNumber(0);
         let multiplier = 1;
         // While converting, the numbers are assumed to be unsigned
         // Detect and remember if number was negative
-        if (repStr.charAt(0) === '-') {
-            repStr = repStr.substr(1);
+        if (rep.charAt(0) === '-') {
+            rep = rep.substr(1);
             multiplier = -1;
         }
         // Digits at positions in some representation are represented by multiple characters,
         // so it's necessary to convert valueString to list of strings
-        const strArr = representationStrToStrArray(repStr, base);
+        const strArr = representationStrToStrArray(rep, base);
         // The value at each position is calculated by taking the value of digit
         // and multiplying it by the base of number to the power of exponent
 
@@ -118,12 +119,10 @@ export function arbitraryIntegralToDecimal(
         // So the starting value of exponent is the count of elements in lis -1
         const exponent = strArr.length - 1;
         for (let i = 0; i <= exponent; i++) {
-            result = result.plus(
-                new BigNumber(
-                    BaseDigits.getValue(strArr[i], base) *
-                        Math.pow(base, exponent - i)
-                )
-            );
+            const expValue = Math.pow(base, exponent - i);
+            const digitValue = BaseDigits.getValue(strArr[i], base);
+            const toAdd = new BigNumber(digitValue * expValue);
+            result = result.plus(toAdd);
         }
         return result.multipliedBy(multiplier);
     }
@@ -256,7 +255,7 @@ export function splitToDigits(
     return [new Digits(result[0], base), new Digits(result[1], base)];
 }
 
-export function splitToDigitsList( num: BigNumber | number | string,  base = 10): Digit[] {
+export function splitToDigitsList(num: BigNumber | number | string, base = 10): Digit[] {
     const [integerPart, fractionalPart] = splitToPartsArr(num, base);
     return [
         ...integerPart.map((digit, index) => {
@@ -265,7 +264,7 @@ export function splitToDigitsList( num: BigNumber | number | string,  base = 10)
                 base,
                 position: integerPart.length - 1 - index,
                 representationInBase: digit
-            }
+            };
         }),
         ...fractionalPart.map((digit, index) => {
             return {
@@ -273,7 +272,16 @@ export function splitToDigitsList( num: BigNumber | number | string,  base = 10)
                 base,
                 position: -1 * (index + 1),
                 representationInBase: digit
-            }
+            };
         })
-    ]
+    ];
 }
+
+export function serializeRepresentationStr(representation: string): string {
+   return representation
+       .replace('−', '-')
+       .replace(',', '.')
+       .replace(/\s+/g, ' ')
+       .trim()
+}
+

--- a/libs/calc-arithmetic/src/lib/positional/addition.spec.ts
+++ b/libs/calc-arithmetic/src/lib/positional/addition.spec.ts
@@ -4,7 +4,7 @@ import {
     addPositionalNumbers,
     extractResultDigitsFromAddition
 } from './addition';
-import { fromNumber, AdditionPositionResult } from '@calc/calc-arithmetic';
+import { AdditionPositionResult, fromNumber } from '@calc/calc-arithmetic';
 import { AdditionOperand } from '../models';
 import { fromStringDirect } from './base-converter';
 
@@ -582,83 +582,83 @@ describe('addition', () => {
         });
     });
 
+
     describe('#addPositionalNumbers', () => {
-        it('should add 2 decimal positional numbers correctly', () => {
-            // given
-            const a = fromNumber(5999, 10).result;
-            const b = fromNumber(5999, 10).result;
+        describe('when numbers are base 2', () => {
+            const base = 2;
 
-            // when
-            const result = addPositionalNumbers([a, b]).numberResult.toDigitsList();
+            test.each([
+                ['0', '0', '0'],
+                ['-1', '1', '0'],
+                ['111011', '101101', '1101000'],
+                ['-111', '-111', '-1110'],
+                ['100', '-10', '10'],
+                ['0.00101', '-11101', '-11100.11011'],
+                ['10010', '0.00110', '10010.00110'],
+                ['10010', '-0.00110', '10001.11010']
+            ])('addPositionalNumbers([%i, %i]) should return proper result', (a: string, b: string, expected: string) => {
+                // given
+                const numA = fromStringDirect(a, base).result;
+                const numB = fromStringDirect(b, base).result;
 
-            // then
-            const expected = fromNumber(11998, 10).result.toDigitsList();
-            expect(result).toEqual(expected);
+                // when
+                const result = addPositionalNumbers([numA, numB]).numberResult.toDigitsList();
+
+                // then
+                const numExpected = fromStringDirect(expected, base).result.toDigitsList();
+                expect(result).toEqual(numExpected);
+            });
         });
 
-        it('should add 2 zeros correctly', () => {
-            // given
-            const a = fromNumber(0, 10).result;
-            const b = fromNumber(0, 10).result;
+        describe('when numbers are base 10', () => {
+            const base = 10;
 
-            // when
-            const result = addPositionalNumbers([a, b]).numberResult.toDigitsList();
+            test.each([
+                [0, 0, 0],
+                [-1, 1, 0],
+                [5999, 5999, 11998],
+                [-199, -123, -322],
+                [10, -20, -10],
+                [10, 0.0009, 10.0009],
+                [10.1236, 0.0009, 10.1245],
+                [10.1236, -0.0009, 10.1227],
+            ])('addPositionalNumbers([%i, %i]) should return proper result', (a, b, expected) => {
+                // given
+                const numA = fromNumber(a, base).result;
+                const numB = fromNumber(b, base).result;
 
-            // then
-            const expected = fromNumber(0, 10).result.toDigitsList();
-            expect(result).toEqual(expected);
+                // when
+                const result = addPositionalNumbers([numA, numB]).numberResult.toDigitsList();
+
+                // then
+                const numExpected = fromNumber(expected, base).result.toDigitsList();
+                expect(result).toEqual(numExpected);
+            });
         });
 
-        it('should add binary numbers correctly', () => {
-            // given
-            const a = fromNumber(4, 2).result;
-            const b = fromNumber(2, 2).result;
+        describe('when numbers are base 64', () => {
+            const base = 64;
 
-            // when
-            const result = addPositionalNumbers([a, b]).numberResult.toDigitsList();
+            test.each([
+                ['00', '00', '00'],
+                ['-01', '01', '00'],
+                ['56 34 21', '11 08 19', '01 03 42 40'],
+                ['10', '-20', '-10'],
+                ['10', '-20', '-10'],
+                ['12 13.45', '44 32', '56 45.45'],
+                ['12 13.45', '-44 32', '-32 18.19'],
+            ])('addPositionalNumbers([%s, %s]) should return proper result', (a: string, b: string, expected: string) => {
+                // given
+                const numA = fromStringDirect(a, base).result;
+                const numB = fromStringDirect(b, base).result;
 
-            // then
-            const expected = fromNumber(6, 2).result.toDigitsList();
-            expect(result).toEqual(expected);
-        });
+                // when
+                const result = addPositionalNumbers([numA, numB]).numberResult.toDigitsList();
 
-        it('should add positive and negative numbers correctly', () => {
-            // given
-            const a = fromNumber(10, 10).result;
-            const b = fromNumber(-20, 10).result;
-
-            // when
-            const result = addPositionalNumbers([a, b]);
-
-            // then
-            const expected = fromNumber(-10, 10).result.toString();
-            expect(result.numberResult.toString()).toEqual(expected);
-        });
-
-        it('should add two positive numbers with fractional part correctly', () => {
-            // given
-            const a = fromNumber(10.1236, 10).result;
-            const b = fromNumber(0.0009, 10).result;
-
-            // when
-            const result = addPositionalNumbers([a, b]);
-
-            // then
-            const expected = fromNumber(10.1245, 10).result.toString();
-            expect(result.numberResult.toString()).toEqual(expected);
-        });
-
-        it('should add two positive and negative numbers with fractional part correctly', () => {
-            // given
-            const a = fromNumber(10.1236, 10).result;
-            const b = fromNumber(-0.0009, 10).result;
-
-            // when
-            const result = addPositionalNumbers([a, b]);
-
-            // then
-            const expected = fromNumber(10.1227, 10).result.toString();
-            expect(result.numberResult.toString()).toEqual(expected);
+                // then
+                const numExpected = fromStringDirect(expected, base).result.toDigitsList();
+                expect(result).toEqual(numExpected);
+            });
         });
     });
 
@@ -790,6 +790,6 @@ describe('addition', () => {
                 }
             ];
             expect(digits).toEqual(expected);
-        })
-    })
+        });
+    });
 });

--- a/libs/calc-arithmetic/src/lib/positional/addition.ts
+++ b/libs/calc-arithmetic/src/lib/positional/addition.ts
@@ -1,8 +1,8 @@
 import { BaseDigits } from './base-digits';
 import { PositionalNumber } from './representations';
 import { fromNumber, fromStringDirect } from './base-converter';
-import { AdditionOperand, AdditionPositionResult, AdditionResult, Digit, PositionResult } from '../models';
-import { getMergedExtension, hasInfiniteExtension, mergeExtensionDigits } from './complement-extension';
+import { AdditionOperand, AdditionPositionResult, AdditionResult } from '../models';
+import { getMergedExtension, hasInfiniteExtension } from './complement-extension';
 import { ComplementConverter } from './complement-converter';
 import { buildLookup, findPositionRange, NUM_ADDITIONAL_EXTENSIONS } from './operation-utils';
 import { OperationType } from '../models/operation';
@@ -14,7 +14,7 @@ export function addPositionalNumbers(numbers: PositionalNumber[]): AdditionResul
     }
     const numbersAsDigits = numbers.map((number) => number.complement.toDigitsList());
     const result = addDigitsArrays(numbersAsDigits);
-    return {...result, numberOperands: numbers};
+    return { ...result, numberOperands: numbers };
 }
 
 export function areSameBaseNumbers(numbers: PositionalNumber[]): boolean {
@@ -44,6 +44,7 @@ export function addDigitsArrays(digits: AdditionOperand[][]): AdditionResult {
             ...allCarriesAtCurrentPosition.map((carry) => ({ ...carry, isCarry: true })),
             ...allDigitsAtCurrentPosition
         ];
+
 
         const positionResult = addDigitsAtPosition(digitsToAdd, currentPosition, base);
 
@@ -90,7 +91,7 @@ export function addDigitsArrays(digits: AdditionOperand[][]): AdditionResult {
 
 export function extractResultDigitsFromAddition(positionResults: AdditionPositionResult[]): AdditionOperand[] {
     const digitsFromPositions: AdditionOperand[] = positionResults.map((res) => {
-        return {...res.valueAtPosition};
+        return { ...res.valueAtPosition };
     });
     const carryDigitsNotConsideredInResult: AdditionOperand[] = [];
 
@@ -112,28 +113,28 @@ export function mergeExtensionDigitsForAddition(resultDigits: AdditionOperand[],
     const firstDifferentIndex = findFirstNonRepeatingDigitIndex(resultDigits);
 
     let startPositionIndex = firstDifferentIndex === -1
-        ? rest.length -1
+        ? rest.length - 1
         : firstDifferentIndex;
 
-    const positionIndexBeforeStart = startPositionIndex -1;
+    const positionIndexBeforeStart = startPositionIndex - 1;
 
     const shouldStartFromPreviousPosition = startPositionIndex >= 1
         && prevPositionGeneratedFromInitialDigits(startPositionIndex, rest, positionResults);
 
-    if(shouldStartFromPreviousPosition) startPositionIndex = positionIndexBeforeStart;
+    if (shouldStartFromPreviousPosition) startPositionIndex = positionIndexBeforeStart;
 
     const startPosition = rest[startPositionIndex].position;
     const mergedExtension = getMergedExtension(extensionDigit, startPosition + 1);
     const nonExtensionDigits = rest.slice(startPositionIndex);
 
-    return [mergedExtension, ...nonExtensionDigits]
+    return [mergedExtension, ...nonExtensionDigits];
 }
 
 function prevPositionGeneratedFromInitialDigits(index: number, digits: AdditionOperand[], positionResults: AdditionPositionResult[]): boolean {
-    const prevPosition = digits[index -1].position;
+    const prevPosition = digits[index - 1].position;
     const prevPositionResult = positionResults.find((res) => res.valueAtPosition.position === prevPosition);
 
-    return positionGeneratedFromInitialDigits(prevPositionResult)
+    return positionGeneratedFromInitialDigits(prevPositionResult);
 }
 
 function positionGeneratedFromInitialDigits(positionResult: AdditionPositionResult): boolean {
@@ -153,7 +154,11 @@ export function buildPositionalNumberFromDigits(resultDigits: AdditionOperand[])
 
     resultDigits.forEach((digit) => {
         const firstFractionalPartDigitIndex = -1;
-        if (digit.position === firstFractionalPartDigitIndex) complementStr += '.';
+        if (digit.position === firstFractionalPartDigitIndex) {
+            if( base > 36)
+                complementStr = complementStr.slice(0, -1);
+            complementStr += '.'
+        }
         complementStr += base > 36 ? digit.representationInBase + ' ' : digit.representationInBase;
     });
 

--- a/libs/calc-arithmetic/src/lib/positional/base-converter.spec.ts
+++ b/libs/calc-arithmetic/src/lib/positional/base-converter.spec.ts
@@ -63,7 +63,7 @@ describe('StandardBaseConverter fromNumber tests', () => {
         expect(result.complement.toString()).toEqual(expectedComplement);
     });
 
-    it('converts positive floating base 10 to base 2 from number', () => {
+    it('converts positive floating base 10 to base 2', () => {
         // given
         const input = 25.5;
         const base = 2;
@@ -76,6 +76,19 @@ describe('StandardBaseConverter fromNumber tests', () => {
         // then
         expect(result.valueInBase).toEqual(expected);
         expect(result.complement.toString()).toEqual(expectedComplement);
+    });
+
+    it('converts 0 to base 64', () => {
+        // given
+        const input = 0;
+        const base = 64;
+        const expected = '00';
+
+        // when
+        const result = BaseConverter.fromNumber(input, base).result;
+
+        // then
+        expect(result.valueInBase).toEqual(expected);
     });
 });
 
@@ -260,7 +273,7 @@ describe('StandardBaseConverter fromString tests', () => {
 describe('StandardBaseConverter fromStringDirect tests', () => {
     const BaseConverter = new StandardBaseConverter();
 
-    it('converts positive base 2 integer to base 10', () => {
+    it('converts positive base 2 integer', () => {
         // given
         const input = '11001';
         const inputbase = 2;
@@ -277,7 +290,7 @@ describe('StandardBaseConverter fromStringDirect tests', () => {
         expect(result.complement.toString()).toEqual(expectedComplement);
     });
 
-    it('converts negative base 2 integer to base 10', () => {
+    it('converts negative base 2 integer', () => {
         // given
         const input = '-11001';
         const inputbase = 2;
@@ -294,7 +307,7 @@ describe('StandardBaseConverter fromStringDirect tests', () => {
         expect(result.complement.toString()).toEqual(expectedComplement);
     });
 
-    it('converts positive floating base 2 to base 10', () => {
+    it('converts positive floating base 2', () => {
         // given
         const input = '11001.1';
         const inputbase = 2;
@@ -311,7 +324,7 @@ describe('StandardBaseConverter fromStringDirect tests', () => {
         expect(result.complement.toString()).toEqual(expectedComplement);
     });
 
-    it('converts negative floating base 2 to base 10', () => {
+    it('converts negative floating base 2', () => {
         // given
         const input = '-11001.1';
         const inputbase = 2;
@@ -328,7 +341,7 @@ describe('StandardBaseConverter fromStringDirect tests', () => {
         expect(result.complement.toString()).toEqual(expectedComplement);
     });
 
-    it('converts positive floating base 16 to base 10', () => {
+    it('converts positive floating base 16', () => {
         // given
         const input = 'FF.8';
         const inputbase = 16;
@@ -345,7 +358,7 @@ describe('StandardBaseConverter fromStringDirect tests', () => {
         expect(result.complement.toString()).toEqual(expectedComplement);
     });
 
-    it('converts negative floating base 16 to base 10', () => {
+    it('converts negative floating base 16', () => {
         // given
         const input = '-FF.8';
         const inputbase = 16;
@@ -362,7 +375,7 @@ describe('StandardBaseConverter fromStringDirect tests', () => {
         expect(result.complement.toString()).toEqual(expectedComplement);
     });
 
-    it('converts positive floating base 2 to base 8', () => {
+    it('converts positive floating base 2', () => {
         // given
         const input = '11001.1';
         const inputbase = 2;
@@ -382,13 +395,42 @@ describe('StandardBaseConverter fromStringDirect tests', () => {
     it('throws error if repStr does match input base', () => {
         // given
         const input = '-FF8.923';
-        const inputbase = 10;
-        const outputbase = 16;
+        const inputBase = 10;
 
         // then
         expect(() => {
-            BaseConverter.fromStringDirect(input, inputbase);
+            BaseConverter.fromStringDirect(input, inputBase);
         }).toThrow();
+    });
+
+    it('converts positive base64', () => {
+        // given
+        const input = '12 45 23';
+        const inputbase = 64;
+        const expectedValue = new BigNumber(52055);
+
+        // when
+        const conv = BaseConverter.fromStringDirect(input, inputbase);
+        const result = conv.result;
+
+        // then
+        expect(result.valueInBase).toEqual(input);
+        expect(result.decimalValue).toEqual(expectedValue);
+    });
+
+    it('converts negative base64', () => {
+        // given
+        const input = '-32 18.19';
+        const inputbase = 64;
+        const expectedValue = new BigNumber(-2066.296875);
+
+        // when
+        const conv = BaseConverter.fromStringDirect(input, inputbase);
+        const result = conv.result;
+
+        // then
+        expect(result.valueInBase).toEqual(input);
+        expect(result.decimalValue).toEqual(expectedValue);
     });
 
 });
@@ -484,6 +526,21 @@ describe('fromString tests', () => {
         const inputbase = 64;
         const outputbase = 10;
         const expected = new BigNumber(50029);
+
+        // when
+        const result = fromString(input, inputbase, outputbase)
+            .result;
+
+        // then
+        expect(result.valueInBase).toEqual(expected.toString());
+    });
+
+    it('should convert b64 number with fractional part', () => {
+        // given
+        const input = '12 13.45';
+        const inputbase = 64;
+        const outputbase = 10;
+        const expected = new BigNumber(781.703125);
 
         // when
         const result = fromString(input, inputbase, outputbase)

--- a/libs/calc-arithmetic/src/lib/positional/complement-converter.spec.ts
+++ b/libs/calc-arithmetic/src/lib/positional/complement-converter.spec.ts
@@ -1,4 +1,5 @@
 import { ComplementConverter } from './complement-converter';
+import { Digit } from '@calc/calc-arithmetic';
 
 describe('getPositiveComplement tests', () => {
     it('returns valid complement for positive number', () => {
@@ -202,6 +203,35 @@ describe('getComplement tests', () => {
         const expected = '(9)90';
         expect(actual.toString()).toEqual(expected)
     });
+});
+
+describe('toDigitsList tests', () => {
+   it('should return proper digit list for b64 number', () => {
+       // given
+       const input = '00';
+       const base = 64;
+
+       // when
+       const actual = ComplementConverter.getComplement(input, base).toDigitsList();
+
+       // then
+       const expected: Digit[] = [
+           {
+               base: 64,
+               isComplementExtension: true,
+               position: 1,
+               representationInBase: '(00)',
+               valueInDecimal: 0
+           },
+           {
+               base: 64,
+               position: 0,
+               representationInBase: '00',
+               valueInDecimal: 0
+           }
+       ];
+       expect(actual).toEqual(expected);
+   })
 });
 
 describe('isNegative tests', () => {

--- a/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
+++ b/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
@@ -63,13 +63,13 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange }) => {
     const [operation, setOperation] = useState<Operation>(allOperations[0]);
     const [algorithm, setAlgorithm] = useState<OperationAlgorithm>(subtractionAlgorithms[0]);
     const [operands, setOperands] = useState<ValidatedOperand[]>(
-        [{valid: true, representation: '10'}, {valid: true, representation: '9'}, {valid: true, representation: '2'}]
+        [{valid: true, representation: '12 13.45'}, {valid: true, representation: '44 32'}]
     );
     const [canAddOperand] = useState(true);
     const [canCalculate, setCanCalculate] = useState(false);
 
     const initialValues: FormValues = {
-        base: 10,
+        base: 64,
         representation: '0.0',
         operands: []
     };


### PR DESCRIPTION
- fix forNumber cases where fractional part
  was 0 length, but the represention for number
  was stored as "1234." instead of "1234"
- add serializers for replacing invalid
  delimiters, signs and multiple spaces
  from representation strings

closes #23 