### PR TITLE
DnD does not change operand order #41

### DIFF
--- a/libs/common-ui/src/lib/components/save-as-image/save-as-image.spec.tsx
+++ b/libs/common-ui/src/lib/components/save-as-image/save-as-image.spec.tsx
@@ -2,7 +2,8 @@ import { mount } from 'enzyme';
 import React from 'react';
 import { SaveAsImageButton } from '@calc/common-ui';
 import { saveAs } from 'file-saver';
-import DomToImage from 'dom-to-image'
+import DomToImage from 'dom-to-image';
+import { tick } from '@calc/utils';
 import Mock = jest.Mock;
 
 jest.mock(
@@ -88,9 +89,3 @@ describe('SaveAsImageButton', () => {
         expect(consoleLogMock).toBeCalledWith(errorMessage);
     });
 });
-
-function tick() {
-    return new Promise(resolve => {
-        setTimeout(resolve, 0);
-    })
-}

--- a/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
+++ b/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
@@ -7,14 +7,14 @@ import {
     isValidString, multiplicationAlgorithms,
     Operation,
     OperationAlgorithm,
-    OperationType, subtractionAlgorithms
+    OperationType,
 } from '@calc/calc-arithmetic';
 import { useTranslation } from 'react-i18next';
 import { clean } from '@calc/utils';
 import { useFormik } from 'formik';
 import { Button, createStyles, TextField, Theme } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import { OperandList, ValidatedOperand } from '../operand-list/operand-list';
+import { OperandList, DndOperand } from '../operand-list/operand-list';
 
 interface FormValues {
     base: number;
@@ -23,7 +23,7 @@ interface FormValues {
 }
 
 interface P {
-    onSubmit: (base: number, representations: ValidatedOperand[], operation: Operation, algorithm: OperationAlgorithm) => void;
+    onSubmit: (base: number, representations: DndOperand[], operation: Operation, algorithm: OperationAlgorithm) => void;
     onOperationChange: (operation: OperationType) => void;
 }
 
@@ -62,8 +62,8 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange }) => {
     const { t } = useTranslation();
     const [operation, setOperation] = useState<Operation>(allOperations[2]);
     const [algorithm, setAlgorithm] = useState<OperationAlgorithm>(multiplicationAlgorithms[0]);
-    const [operands, setOperands] = useState<ValidatedOperand[]>(
-        [{valid: true, representation: '0.003'}, {valid: true, representation: '12.123'}]
+    const [operands, setOperands] = useState<DndOperand[]>(
+        [{valid: true, representation: '0.003', dndKey: '1'}, {valid: true, representation: '12.123', dndKey: '2'}]
     );
     const [canAddOperand] = useState(true);
     const [canCalculate, setCanCalculate] = useState(false);
@@ -94,11 +94,11 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange }) => {
 
     const handleAdd = () => {
         const defaultStr = BaseDigits.getRepresentation(0, form.values.base);
-        setOperands((prev) => [...prev, {representation: defaultStr, valid: true}]);
+        setOperands((prev) => [...prev, {representation: defaultStr, valid: true, dndKey: `${Date.now()}`}]);
     };
 
     const handleSubmit = (values: FormValues) => {
-        setOperands((prev) => [...prev, {representation: values.representation, valid: true}])
+        setOperands((prev) => [...prev, {representation: values.representation, valid: true, dndKey: `${Date.now()}`}])
     };
 
     const validate = (values: FormValues) => {
@@ -116,7 +116,7 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange }) => {
         return algorithmMap[op.type] || [];
     };
 
-    const handleOperandChange = (newOperands: ValidatedOperand[]) => {
+    const handleOperandChange = (newOperands: DndOperand[]) => {
         setOperands(newOperands)
     };
 

--- a/libs/positional-calculator/src/lib/operand-input/operand-input.spec.tsx
+++ b/libs/positional-calculator/src/lib/operand-input/operand-input.spec.tsx
@@ -1,23 +1,108 @@
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import React from 'react';
 import { OperandInput } from './operand-input';
+import { tick } from '@calc/utils';
 
 describe('OperandInput', () => {
-    let container;
-    const onRemove = jest.fn();
+    it('should render', () => {
+        // when
+        const container = mount(
+            <OperandInput
+                base={10}
+                representationStr={'0.0'}
+                index={0}
+                onRemove={jest.fn()}
+                onRepresentationChange={jest.fn()}
+            />
+        );
 
-    beforeEach(() => {
-        container = shallow(
+        // then
+        expect(container).toBeTruthy();
+    });
+
+    it('should call onRepresentationChange handler when representation changes', async () => {
+        // given
+        const onChange = jest.fn();
+        const onRemove = jest.fn();
+        const index = 0;
+        const value = '12.8';
+        const isValid = true;
+
+        const container = mount(
             <OperandInput
                 base={10}
                 representationStr={'0.0'}
                 index={0}
                 onRemove={onRemove}
+                onRepresentationChange={onChange}
             />
         );
+
+        //when
+        container
+            .find('input')
+            .at(0)
+            .simulate('change',  { target: { value } });
+
+        await tick();
+
+        // then
+        const lastCall = onChange.mock.calls.pop();
+        expect(lastCall).toEqual([value, index, isValid]);
     });
 
-    it('should render', () => {
-        expect(container).toBeTruthy();
+    it('should display error message when representation is not valid for given base ', async () => {
+        // given
+        const onChange = jest.fn();
+        const onRemove = jest.fn();
+        const errorClassName = '.Mui-error';
+
+        const container = mount(
+            <OperandInput
+                base={10}
+                representationStr={'FFE.8'}
+                index={0}
+                onRemove={onRemove}
+                onRepresentationChange={onChange}
+            />
+        );
+
+        //when
+        const errorMessage =container
+            .find(errorClassName)
+            .at(0);
+
+        await tick();
+
+        // then
+        expect(errorMessage.length).toEqual(1);
     });
+
+    it('should call onRemove handler when remove button is clicked', async () => {
+        // given
+        const onChange = jest.fn();
+        const onRemove = jest.fn();
+
+        const container = mount(
+            <OperandInput
+                base={10}
+                representationStr={'10'}
+                index={0}
+                onRemove={onRemove}
+                onRepresentationChange={onChange}
+            />
+        );
+
+        //when
+        container
+            .find('button')
+            .at(0)
+            .simulate('click');
+
+        await tick();
+
+        // then
+        expect(onRemove).toBeCalled();
+    })
 });
+

--- a/libs/positional-calculator/src/lib/operand-input/operand-input.tsx
+++ b/libs/positional-calculator/src/lib/operand-input/operand-input.tsx
@@ -12,7 +12,6 @@ interface P extends ListItemProps {
     onRepresentationChange?: (representationStr: string, index: number, valid: boolean) => void;
 }
 
-
 export const OperandInput: FC<P> = ({ representationStr, onRepresentationChange, base, index, onRemove, ...rest }) => {
     const { t } = useTranslation();
     const [representation, setRepresentation] = useState(representationStr);

--- a/libs/positional-calculator/src/lib/operand-list/operand-list.tsx
+++ b/libs/positional-calculator/src/lib/operand-list/operand-list.tsx
@@ -6,15 +6,16 @@ import { OperandInput } from '../operand-input/operand-input';
 import { useTranslation } from 'react-i18next';
 import AddIcon from '@material-ui/icons/Add';
 
-export interface ValidatedOperand {
+export interface DndOperand {
     representation: string;
     valid: boolean;
+    dndKey: string;
 }
 
 interface P {
     inputBase: number;
-    operands: ValidatedOperand[];
-    onChange: (operands: ValidatedOperand[]) => void;
+    operands: DndOperand[];
+    onChange: (operands: DndOperand[]) => void;
     onAdd: () => void;
     canAdd: boolean;
 }
@@ -62,13 +63,12 @@ export const OperandList: FC<P> = ({ inputBase, operands, onChange, onAdd, canAd
     const classes = useStyles();
     const { t } = useTranslation();
 
-
     const onDragEnd = (result: any) => {
         if (!result.destination) {
             return;
         }
 
-        const newItems: ValidatedOperand[] = reorder(
+        const newItems: DndOperand[] = reorder(
             operands,
             result.source.index,
             result.destination.index
@@ -86,13 +86,13 @@ export const OperandList: FC<P> = ({ inputBase, operands, onChange, onAdd, canAd
 
     const handleChange = (representationStr: string, index: number, isValid: boolean) => {
         const newOperands = [...operands];
-        newOperands[index] = { representation: representationStr, valid: isValid };
+        newOperands[index] = { ...newOperands[index], representation: representationStr, valid: isValid };
         onChange(newOperands);
     };
 
     const items = operands.map((item, index) => {
         return (
-            <Draggable key={index} draggableId={`${index}`} index={index}>
+            <Draggable key={item.dndKey} draggableId={`${item.dndKey}`} index={index}>
                 {(provided, snapshot) => (
                     <OperandInput
                         ContainerComponent="li"
@@ -111,7 +111,6 @@ export const OperandList: FC<P> = ({ inputBase, operands, onChange, onAdd, canAd
             </Draggable>
         );
     });
-
 
     return (
         <div>

--- a/libs/positional-calculator/src/lib/positional-calculator-view/positional-calculator-view.tsx
+++ b/libs/positional-calculator/src/lib/positional-calculator-view/positional-calculator-view.tsx
@@ -12,7 +12,7 @@ import { PaddedGrid } from '@calc/grid';
 import { createStyles, Theme } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { SaveAsImageButton, Section, ViewWrapper } from '@calc/common-ui';
-import { ValidatedOperand } from '../operand-list/operand-list';
+import { DndOperand } from '../operand-list/operand-list';
 import { CalculatorOptions } from '../calculator-options/calculator-options';
 import { getGroupBuilder } from '../core/operation-group-builer';
 import { OperationResultComponent } from '../operation-result/operation-result';
@@ -53,7 +53,7 @@ export const PositionalCalculatorView: FC = () => {
 
     const onSubmit = function <T extends AlgorithmType>(
         base: number,
-        representations: ValidatedOperand[],
+        representations: DndOperand[],
         operation: Operation,
         algorithm: OperationAlgorithm<T>
     ) {

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -10,4 +10,5 @@ export * from './lib/functions/in-range';
 export * from './lib/functions/obj-array-equal';
 export * from './lib/functions/list-keys';
 export * from './lib/functions/deep-assign';
+export * from './lib/functions/test-uitls';
 export * from './lib/hooks/use-mount-effect';

--- a/libs/utils/src/lib/functions/test-uitls.ts
+++ b/libs/utils/src/lib/functions/test-uitls.ts
@@ -1,0 +1,5 @@
+export function tick() {
+    return new Promise(resolve => {
+        setTimeout(resolve, 0);
+    })
+}


### PR DESCRIPTION
- RC: every time DnD occured, the operands was reordererd,
  but when they came back again as props, the keys for
  operands were based on index of op in list, and were
  reasigned, to fix this, each item now gets unique key
- add tick to test utils
- add missing tests for operand input

closes #41 