### PR TITLE
Subtraction wrong operands in tooltip #88

### DIFF
--- a/libs/calc-arithmetic/src/lib/positional/subtraction.spec.ts
+++ b/libs/calc-arithmetic/src/lib/positional/subtraction.spec.ts
@@ -316,35 +316,224 @@ describe('subtraction', () => {
                             valueInDecimal: 7,
                             representationInBase: '7',
                             base: 10,
-                            position: 1,
+                            position: 1
                         },
                         {
                             valueInDecimal: 6,
                             representationInBase: '6',
                             base: 10,
-                            position: 1,
-                        },
+                            position: 1
+                        }
                     ]
                 };
                 expect(positionWithBorrow).toEqual(expected);
+            });
+        });
+
+        describe('when subtracting twp digit arrays when some position is borrowed from, and needs borrow after', () => {
+            let x: SubtractionOperand[];
+            let y: SubtractionOperand[];
+            let result: SubtractionResult;
+
+            beforeEach(() => {
+                // given
+                x = [
+                    {
+                        valueInDecimal: 0,
+                        representationInBase: '(0)',
+                        base: 10,
+                        position: 2,
+                        isComplementExtension: true
+                    },
+                    {
+                        valueInDecimal: 1,
+                        representationInBase: '1',
+                        base: 10,
+                        position: 1
+                    },
+                    {
+                        valueInDecimal: 0,
+                        representationInBase: '0',
+                        base: 10,
+                        position: 0
+                    },
+                    {
+                        valueInDecimal: 0,
+                        representationInBase: '0',
+                        base: 10,
+                        position: -1
+                    }
+                ];
+                y = [
+                    {
+                        valueInDecimal: 0,
+                        representationInBase: '(0)',
+                        base: 10,
+                        position: 1,
+                        isComplementExtension: true
+                    },
+                    {
+                        valueInDecimal: 1,
+                        representationInBase: '1',
+                        base: 10,
+                        position: 0
+                    },
+                    {
+                        valueInDecimal: 1,
+                        representationInBase: '1',
+                        base: 10,
+                        position: -1
+                    }
+                ];
+
+                // when
+                result = subtractDigitArrays([x, y]);
+            });
+
+            it('should subtract two digit arrays correctly', () => {
+                // then
+                const expectedDigits: SubtractionOperand[] = [
+                    {
+                        base: 10,
+                        isComplementExtension: true,
+                        position: 1,
+                        representationInBase: '(0)',
+                        valueInDecimal: 0
+                    },
+                    {
+                        base: 10,
+                        position: 0,
+                        representationInBase: '8',
+                        valueInDecimal: 8
+                    },
+                    {
+                        base: 10,
+                        position: -1,
+                        representationInBase: '9',
+                        valueInDecimal: 9
+                    }
+                ];
+                expect(result.resultDigits).toEqual(expectedDigits);
+            });
+
+            it('should generate proper borrow chain for minuend position that borrows', () => {
+                // then
+                const positionThatBorrows = result.stepResults[0];
+
+                const expected: SubtractionPositionResult = {
+                    borrow: {
+                        amount: 1,
+                        fromPosition: 0,
+                        sourcePosition: -1
+                    },
+                    operands: [
+                        {
+                            base: 10,
+                            borrowChain: [
+                                {
+                                    base: 10,
+                                    position: -1,
+                                    representationInBase: '0',
+                                    valueInDecimal: 0
+                                },
+                                {
+                                    base: 10,
+                                    position: -1,
+                                    representationInBase: '10',
+                                    valueInDecimal: 10
+                                }
+                            ],
+                            position: -1,
+                            representationInBase: '0',
+                            valueInDecimal: 0
+                        },
+                        {
+                            base: 10,
+                            position: -1,
+                            representationInBase: '1',
+                            valueInDecimal: 1
+                        }
+                    ],
+                    valueAtPosition: {
+                        base: 10,
+                        position: -1,
+                        representationInBase: '9',
+                        valueInDecimal: 9
+                    }
+                };
+                expect(positionThatBorrows).toEqual(expected);
+            });
+
+            it('should generate proper borrow chain for minuend position that borrows and is borrowed from', () => {
+                // then
+                const doubleBorrowPosition = result.stepResults[1];
+
+                const expected: SubtractionPositionResult = {
+                    borrow: {
+                        amount: 1,
+                        fromPosition: 1,
+                        sourcePosition: 0
+                    },
+                    operands: [
+                        {
+                            base: 10,
+                            position: 0,
+                            representationInBase: '-1',
+                            valueInDecimal: -1,
+                            borrowChain: [
+                                {
+                                    base: 10,
+                                    position: 0,
+                                    representationInBase: '0',
+                                    valueInDecimal: 0
+                                },
+                                {
+                                    base: 10,
+                                    position: 0,
+                                    representationInBase: '-1',
+                                    valueInDecimal: -1
+                                },
+                                {
+                                    base: 10,
+                                    position: 0,
+                                    representationInBase: '9',
+                                    valueInDecimal: 9
+                                }
+                            ],
+                        },
+                        {
+                            base: 10,
+                            position: 0,
+                            representationInBase: '1',
+                            valueInDecimal: 1
+                        }
+                    ],
+                    valueAtPosition: {
+                        base: 10,
+                        position: 0,
+                        representationInBase: '8',
+                        valueInDecimal: 8
+                    }
+                };
+                expect(doubleBorrowPosition).toEqual(expected);
             });
         });
     });
 
     describe('#subtractPositionalNumbers', () => {
         describe('when subtracting two operands', () => {
-           it('should return proper result when subtrahend has fraction part and minuend does not', () => {
-               // given
-               const minuend = fromNumber(10, 10).result;
-               const subtrahend = fromNumber(1.1, 10).result;
+            it('should return proper result when subtrahend has fraction part and minuend does not', () => {
+                // given
+                const minuend = fromNumber(10, 10).result;
+                const subtrahend = fromNumber(1.1, 10).result;
 
-               // when
-               const result = subtractPositionalNumbers([minuend, subtrahend]);
+                // when
+                const result = subtractPositionalNumbers([minuend, subtrahend]);
 
-               // then
-               const expected = '8.9';
-               expect(result.numberResult.toString()).toEqual(expected);
-           });
+                // then
+                const expected = '8.9';
+                expect(result.numberResult.toString()).toEqual(expected);
+            });
 
             it('should return proper result for operands with fractional parts', () => {
                 // given
@@ -371,7 +560,7 @@ describe('subtraction', () => {
                 const result = subtractPositionalNumbers([x, y, z]);
 
                 // then
-                const expected: SubtractionOperand []= [
+                const expected: SubtractionOperand [] = [
                     {
                         base: 10,
                         position: 0,
@@ -387,6 +576,6 @@ describe('subtraction', () => {
                 ];
                 expect(result.stepResults[0].operands[0].borrowChain).toEqual(expected);
             });
-        })
-    })
+        });
+    });
 });

--- a/libs/grid/src/lib/core/subtraction-grid.tsx
+++ b/libs/grid/src/lib/core/subtraction-grid.tsx
@@ -50,27 +50,30 @@ export function borrowsToCellConfig(result: SubtractionResult): GridCellConfig[]
         positionIndexLookup[posDigit.position] = index + 1;
     });
 
-    let mostCarriesPerPosition = 0;
+    let mostBorrowsPerPosition = 0;
 
-    result.operands[0].forEach((posResult, index) => {
-        if (posResult.borrowChain) {
-            posResult.borrowChain.slice(1).forEach((borrow) => {
+    const [minuend] = result.operands;
+
+    minuend.forEach((minuendDigit) => {
+        if (minuendDigit.borrowChain) {
+            const [, ...borrows] = minuendDigit.borrowChain;
+            borrows.forEach((borrow) => {
                 if (positionBorrowLookup[borrow.position]) {
                     positionBorrowLookup[borrow.position].push(borrow);
                 } else {
                     positionBorrowLookup[borrow.position] = [borrow];
                 }
 
-                const numCarries = positionBorrowLookup[borrow.position].length;
+                const numBorrows = positionBorrowLookup[borrow.position].length;
 
-                if (mostCarriesPerPosition < numCarries) {
-                    mostCarriesPerPosition = numCarries;
+                if (mostBorrowsPerPosition < numBorrows) {
+                    mostBorrowsPerPosition = numBorrows;
                 }
             });
         }
     });
 
-    const emptyCarryGrid = buildEmptyGrid(width, mostCarriesPerPosition);
+    const emptyCarryGrid = buildEmptyGrid(width, mostBorrowsPerPosition);
 
     Object.entries(positionBorrowLookup).forEach(([strPosition, positionBorrows]) => {
         const numPosition = parseInt(strPosition);

--- a/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
+++ b/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
@@ -68,7 +68,7 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
 
     const [operands, setOperands] = useState<DndOperand[]>(
         defaultOperands ||
-        [{valid: true, representation: '9876', dndKey: '1'}, {valid: true, representation: '7123', dndKey: '2'}]
+        [{valid: true, representation: '10', dndKey: '1'}, {valid: true, representation: '1.1', dndKey: '2'}]
     );
     const [canAddOperand, setCanAddOperand] = useState(true);
     const [canCalculate, setCanCalculate] = useState(false);


### PR DESCRIPTION
- RC: the borrow chain of position result was not
  update properly - it was updated in the global lookup,
  so the overall result was still ok
- copy the updated borrow chain from global lookup to
  position result minuend digit
  
  Closes #88 