### PR TITLE
Replace React-Katex with fork #58

### DIFF
--- a/apps/calc-web/src/app/components/sider-menu/sider-menu.tsx
+++ b/apps/calc-web/src/app/components/sider-menu/sider-menu.tsx
@@ -3,13 +3,13 @@ import { useTranslation } from 'react-i18next';
 import HomeIcon from '@material-ui/icons/Home';
 import BuildIcon from '@material-ui/icons/Build';
 import MenuBookIcon from '@material-ui/icons/MenuBook';
-import { MenuTree, TreeNodeProps } from '@calc/common-ui';
+import { MenuTree, TreeNode } from '@calc/common-ui';
 
 
 export const SiderMenu = () => {
     const { t } = useTranslation();
 
-    const nodes: TreeNodeProps[] = [
+    const nodes: TreeNode[] = [
         {
             labelText: t('routes.home'),
             path: '/',

--- a/libs/base-converter/src/lib/components/associated-base-conversion-result/associated-base-conversion-result.tsx
+++ b/libs/base-converter/src/lib/components/associated-base-conversion-result/associated-base-conversion-result.tsx
@@ -3,7 +3,7 @@ import { AssociatedBaseConversion } from '@calc/calc-arithmetic';
 import { PositionalNumberComponent } from '@calc/positional-ui';
 import { makeStyles } from '@material-ui/core/styles';
 import { createStyles, Theme } from '@material-ui/core';
-import { InlineMath } from 'react-katex';
+import { InlineMath } from '@calc/common-ui';
 
 interface P {
     conversion: AssociatedBaseConversion;

--- a/libs/base-converter/src/lib/components/conversion-details/result-equation/result-equation.tsx
+++ b/libs/base-converter/src/lib/components/conversion-details/result-equation/result-equation.tsx
@@ -1,9 +1,9 @@
 import React, { FC } from 'react';
 import { Conversion } from '@calc/calc-arithmetic';
 import { PositionalNumberComponent } from '@calc/positional-ui';
-import { InlineMath } from 'react-katex';
 import { makeStyles } from '@material-ui/core/styles';
 import { createStyles, Theme } from '@material-ui/core';
+import { InlineMath } from '@calc/common-ui';
 
 interface P {
     conversion: Conversion;

--- a/libs/base-converter/src/lib/components/conversion-to-decimal/conversion-to-decimal.tsx
+++ b/libs/base-converter/src/lib/components/conversion-to-decimal/conversion-to-decimal.tsx
@@ -3,7 +3,7 @@ import { ConversionToDecimal } from '@calc/calc-arithmetic';
 import { PositionalNumberComponent } from '@calc/positional-ui';
 import { makeStyles } from '@material-ui/core/styles';
 import { createStyles, Theme } from '@material-ui/core';
-import { InlineMath } from 'react-katex';
+import { InlineMath } from '@calc/common-ui';
 
 interface P {
     conversionStage: ConversionToDecimal;

--- a/libs/common-ui/src/index.ts
+++ b/libs/common-ui/src/index.ts
@@ -8,10 +8,13 @@ export { AppTheme, getTheme, availableThemes } from './lib/themes';
 export { ExtendedSelect } from './lib/components/extended-select/extended-select';
 export { ExtendedOption } from './lib/core/models/extended-option';
 export { SaveAsImageButton } from './lib/components/save-as-image/save-as-image-button';
-export { ViewWrapper } from './lib/components/view-wrapper/view-wrapper'
-export { Alert } from './lib/components/alert/alert'
-export { NavigationBreadcrumbs } from './lib/components/navigation-breadcrumbs/navigation-breadcrumbs'
-export { TreeNodeProps, MenuTree } from './lib/components/menu-tree/menu-tree'
+export { ViewWrapper } from './lib/components/view-wrapper/view-wrapper';
+export { Alert } from './lib/components/alert/alert';
+export { NavigationBreadcrumbs } from './lib/components/navigation-breadcrumbs/navigation-breadcrumbs';
+export { MenuTree } from './lib/components/menu-tree/menu-tree';
 export * from './lib/core/models/form-errors';
 export * from './lib/core/models/extended-option';
 export { ListEntry } from './lib/core/models/list-entry';
+export { TreeNode } from './lib/core/models/tree-node';
+export { InlineMath } from './lib/components/math/inline-math';
+export { BlockMath } from './lib/components/math/block-math';

--- a/libs/common-ui/src/lib/components/math/block-math.tsx
+++ b/libs/common-ui/src/lib/components/math/block-math.tsx
@@ -1,0 +1,12 @@
+import React, { FC } from 'react';
+import TeX from '@matejmazur/react-katex';
+
+interface P {
+    math: string;
+}
+
+export const BlockMath: FC<P> = ({math}) => {
+    return (
+        <TeX math={math || ' '} block/>
+    );
+};

--- a/libs/common-ui/src/lib/components/math/inline-math.tsx
+++ b/libs/common-ui/src/lib/components/math/inline-math.tsx
@@ -1,0 +1,12 @@
+import React, { FC } from 'react';
+import TeX from '@matejmazur/react-katex';
+
+interface P {
+    math: string;
+}
+
+export const InlineMath: FC<P> = ({math}) => {
+    return (
+      <TeX math={math || ' '}/>
+    );
+};

--- a/libs/common-ui/src/lib/components/menu-tree/menu-tree.tsx
+++ b/libs/common-ui/src/lib/components/menu-tree/menu-tree.tsx
@@ -1,13 +1,13 @@
 import React, { useCallback, useState } from 'react';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import TreeView from '@material-ui/lab/TreeView';
-import TreeItem, { TreeItemProps } from '@material-ui/lab/TreeItem';
+import TreeItem from '@material-ui/lab/TreeItem';
 import Typography from '@material-ui/core/Typography';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import ArrowRightIcon from '@material-ui/icons/ArrowRight';
-import { SvgIconProps } from '@material-ui/core/SvgIcon';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useMountEffect } from '@calc/utils';
+import { TreeNode } from '../../core/models/tree-node';
 
 declare module 'csstype' {
     interface Properties {
@@ -15,17 +15,6 @@ declare module 'csstype' {
         '--tree-view-bg-color'?: string;
     }
 }
-
-export type TreeNodeProps = Omit<TreeItemProps, 'nodeId'> & {
-    bgColor?: string;
-    color?: string;
-    labelIcon?: React.ElementType<SvgIconProps>;
-    labelInfo?: string;
-    labelText: string;
-    path?: string;
-    childNodes?: TreeNodeProps[];
-};
-
 
 const useTreeItemStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -77,7 +66,7 @@ const useTreeItemStyles = makeStyles((theme: Theme) =>
     })
 );
 
-function StyledTreeItem(props: TreeNodeProps) {
+function StyledTreeItem(props: TreeNode) {
     const classes = useTreeItemStyles();
     const { labelText, labelIcon: LabelIcon, labelInfo, color, bgColor, ...other } = props;
 
@@ -123,7 +112,7 @@ const useStyles = makeStyles(
 );
 
 interface P {
-    nodes: TreeNodeProps[];
+    nodes: TreeNode[];
 }
 
 export function MenuTree(props: P) {
@@ -133,7 +122,7 @@ export function MenuTree(props: P) {
     const { pathname } = useLocation();
     const [expanded, setExpanded] = useState([]);
 
-    const handleClick = useCallback((node: TreeNodeProps) => {
+    const handleClick = useCallback((node: TreeNode) => {
         if (node.path) {
             history.push(node.path);
         }
@@ -160,7 +149,7 @@ export function MenuTree(props: P) {
     });
 
 
-    const renderTree = useCallback((nodes: TreeNodeProps[]) => {
+    const renderTree = useCallback((nodes: TreeNode[]) => {
         return nodes.map((node, idx) => (
             <StyledTreeItem
                 key={idx}

--- a/libs/common-ui/src/lib/components/number-subscript/number-subscript.tsx
+++ b/libs/common-ui/src/lib/components/number-subscript/number-subscript.tsx
@@ -1,5 +1,4 @@
 import React, { FC } from 'react';
-import { InlineMath } from 'react-katex';
 
 interface P {
     value: string;

--- a/libs/common-ui/src/lib/core/models/tree-node.ts
+++ b/libs/common-ui/src/lib/core/models/tree-node.ts
@@ -1,0 +1,13 @@
+import { TreeItemProps } from '@material-ui/lab/TreeItem';
+import React from 'react';
+import { SvgIconProps } from '@material-ui/core/SvgIcon';
+
+export type TreeNode = Omit<TreeItemProps, 'nodeId'> & {
+    bgColor?: string;
+    color?: string;
+    labelIcon?: React.ElementType<SvgIconProps>;
+    labelInfo?: string;
+    labelText: string;
+    path?: string;
+    childNodes?: TreeNode[];
+};

--- a/libs/docs/src/lib/components/markdown-renderer/markdown-renderer.spec.tsx
+++ b/libs/docs/src/lib/components/markdown-renderer/markdown-renderer.spec.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { MarkdownRenderer} from './markdown-renderer';
 import { HeadingRenderer } from '../heading-renderer/heading-renderer';
-import { BlockMath, InlineMath } from 'react-katex';
 import { RendererMapping } from '@calc/docs';
+import { BlockMath, InlineMath } from '@calc/common-ui';
 
 describe('MarkdownRenderer', () => {
     describe('heading renderer', () => {

--- a/libs/docs/src/lib/components/markdown-renderer/markdown-renderer.tsx
+++ b/libs/docs/src/lib/components/markdown-renderer/markdown-renderer.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import ReactMarkdown, { ReactMarkdownProps } from 'react-markdown';
 import 'katex/dist/katex.min.css';
 import RemarkMathPlugin from 'remark-math';
-import { BlockMath, InlineMath } from 'react-katex';
 import { Typography } from '@material-ui/core';
 import { HeadingRenderer } from '../heading-renderer/heading-renderer';
 import { RendererMapping } from '../../..';
+import { BlockMath, InlineMath } from '@calc/common-ui';
 
 interface CodeTagProps {
     language: string;

--- a/libs/positional-calculator/src/lib/addition/addition-position-result/add-at-position-hover-content.tsx
+++ b/libs/positional-calculator/src/lib/addition/addition-position-result/add-at-position-hover-content.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { AdditionOperand, AdditionPositionResult, fromNumber } from '@calc/calc-arithmetic';
-import { InlineMath } from 'react-katex';
+import { InlineMath } from '@calc/common-ui';
 
 interface P {
     positionResult: AdditionPositionResult;

--- a/libs/positional-calculator/src/lib/complement-converter-view/complement-result/complement-result.tsx
+++ b/libs/positional-calculator/src/lib/complement-converter-view/complement-result/complement-result.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from 'react';
 import { PositionalNumber, PositionalSourceType } from '@calc/calc-arithmetic';
-import { InlineMath } from 'react-katex';
 import { makeStyles } from '@material-ui/core/styles';
 import { createStyles, Theme } from '@material-ui/core';
+import { InlineMath } from '@calc/common-ui';
 
 interface P {
     number: PositionalNumber;

--- a/libs/positional-calculator/src/lib/multiplication/multiplication-grid/multiplication-grid.tsx
+++ b/libs/positional-calculator/src/lib/multiplication/multiplication-grid/multiplication-grid.tsx
@@ -82,10 +82,9 @@ export function buildMultiplicationGrid(result: MultiplicationResult): HoverOper
     return {
         lines,
         groups,
-        values
+        values,
     }
 }
-
 
 function getGridLines(info: MultiplicationResultMeta, initialOperandRows: GridCellConfig[][], addOperandRows: GridCellConfig[][]): GridLine[] {
     const lines: GridLine[] = [];
@@ -93,6 +92,8 @@ function getGridLines(info: MultiplicationResultMeta, initialOperandRows: GridCe
     if(info.hasMultiplicandComplement) {
         const complementSeparatorIndex = 0;
         lines.push({ type: LineType.Horizontal, index: complementSeparatorIndex });
+
+        lines.push({ type: LineType.Vertical, index: info.totalWidth  -1});
     }
 
     const offset = info.hasMultiplicandComplement ? 1 : 0;

--- a/libs/positional-calculator/src/lib/multiplication/multiply-position-result/multiply-position-details.tsx
+++ b/libs/positional-calculator/src/lib/multiplication/multiply-position-result/multiply-position-details.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
-import { InlineMath } from 'react-katex';
 import { fromNumber, MultiplicationPositionResult } from '@calc/calc-arithmetic';
+import { InlineMath } from '@calc/common-ui';
 
 interface P {
     result: MultiplicationPositionResult;

--- a/libs/positional-calculator/src/lib/multiplication/multiply-row-result/multiply-row-result.tsx
+++ b/libs/positional-calculator/src/lib/multiplication/multiply-row-result/multiply-row-result.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { digitsToStr, MultiplicationRowResult } from '@calc/calc-arithmetic';
 import { PositionalNumberComponent } from '@calc/positional-ui';
-import { InlineMath } from 'react-katex';
+import { InlineMath } from '@calc/common-ui';
 
 interface P {
     result: MultiplicationRowResult;

--- a/libs/positional-calculator/src/lib/operation-result/operand-row/operand-row.tsx
+++ b/libs/positional-calculator/src/lib/operation-result/operand-row/operand-row.tsx
@@ -1,9 +1,9 @@
 import React, { FC } from 'react';
 import { PositionalNumber } from '@calc/calc-arithmetic';
-import { InlineMath } from 'react-katex';
 import { makeStyles } from '@material-ui/core/styles';
 import { createStyles, Theme } from '@material-ui/core';
 import { PositionalNumberComponent } from '@calc/positional-ui';
+import { InlineMath } from '@calc/common-ui';
 
 interface P {
     operands: PositionalNumber[];

--- a/libs/positional-calculator/src/lib/positional-calculator-view/positional-calculator-view.tsx
+++ b/libs/positional-calculator/src/lib/positional-calculator-view/positional-calculator-view.tsx
@@ -72,7 +72,6 @@ export const PositionalCalculatorView: FC = () => {
 
         setParams(params);
         const res = calculate(params);
-        console.log(res);
         setRes(res);
     };
 

--- a/libs/positional-calculator/src/lib/subtraction/subtraction-position-result/subtraction-position-result.tsx
+++ b/libs/positional-calculator/src/lib/subtraction/subtraction-position-result/subtraction-position-result.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { SubtractionOperand, SubtractionPositionResult } from '@calc/calc-arithmetic';
-import { InlineMath } from 'react-katex';
+import { InlineMath } from '@calc/common-ui';
 
 interface P {
     positionResult: SubtractionPositionResult;

--- a/libs/positional-ui/src/lib/components/positional-number/positional-number-component.tsx
+++ b/libs/positional-ui/src/lib/components/positional-number/positional-number-component.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from 'react';
-import { InlineMath } from 'react-katex';
 import { Tooltip } from '@material-ui/core';
 import { fromString } from '@calc/calc-arithmetic';
 import { replaceAll } from '@calc/utils';
+import { InlineMath } from '@calc/common-ui';
 
 interface P {
     base: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2073,6 +2073,11 @@
                 "@types/yargs": "^13.0.0"
             }
         },
+        "@matejmazur/react-katex": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@matejmazur/react-katex/-/react-katex-3.1.3.tgz",
+            "integrity": "sha512-rBp7mJ9An7ktNoU653BWOYdO4FoR4YNwofHZi+vaytX/nWbIlmHVIF+X8VFOn6c3WYmrLT5FFBjKqCZ1sjR5uQ=="
+        },
         "@material-ui/core": {
             "version": "4.11.0",
             "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.0.tgz",
@@ -6751,8 +6756,7 @@
         "commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "common-tags": {
             "version": "1.8.0",
@@ -13138,11 +13142,11 @@
             }
         },
         "katex": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/katex/-/katex-0.9.0.tgz",
-            "integrity": "sha512-lp3x90LT1tDZBW2tjLheJ98wmRMRjUHwk4QpaswT9bhqoQZ+XA4cPcjcQBxgOQNwaOSt6ZeL/a6GKQ1of3LFxQ==",
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/katex/-/katex-0.12.0.tgz",
+            "integrity": "sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==",
             "requires": {
-                "match-at": "^0.1.1"
+                "commander": "^2.19.0"
             }
         },
         "killable": {
@@ -13873,11 +13877,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
             "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
-        },
-        "match-at": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/match-at/-/match-at-0.1.1.tgz",
-            "integrity": "sha512-h4Yd392z9mST+dzc+yjuybOGFNOZjmXIPKWjxBd1Bb23r4SmDOsk2NYCU2BMUBGbSpZqwVsZYNq26QS3xfaT3Q=="
         },
         "material-ui-popup-state": {
             "version": "1.6.1",
@@ -16572,14 +16571,6 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        },
-        "react-katex": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/react-katex/-/react-katex-2.0.2.tgz",
-            "integrity": "sha512-mk1ezfUF4mBIstjvpfELf9g1rWF1Y1+idXMiOvkFvCLi0JFZDCQdui59VqQcI2ynOpb0jj52TM4kyBjKG+qEBg==",
-            "requires": {
-                "katex": "^0.9.0"
-            }
         },
         "react-markdown": {
             "version": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "private": true,
     "dependencies": {
         "@ant-design/icons": "^4.2.2",
+        "@matejmazur/react-katex": "^3.1.3",
         "@material-ui/core": "^4.11.0",
         "@material-ui/icons": "^4.9.1",
         "@material-ui/lab": "^4.0.0-alpha.56",
@@ -55,6 +56,7 @@
         "g": "^2.0.1",
         "i18next": "^19.4.4",
         "imports-loader": "^1.1.0",
+        "katex": "^0.12.0",
         "material-ui-popup-state": "^1.6.1",
         "path": "^0.12.7",
         "react": "16.12.0",
@@ -62,7 +64,6 @@
         "react-beautiful-dnd": "^13.0.0",
         "react-dom": "16.12.0",
         "react-i18next": "^11.4.0",
-        "react-katex": "^2.0.2",
         "react-markdown": "^4.3.1",
         "react-redux": "^7.2.0",
         "react-router-dom": "^5.2.0",


### PR DESCRIPTION
- remove old react-katex, this fixes the broken overline and
  warning for `componentWillReciveProps`
- wrap new lib with inline and block math components

closes #58 