### PR TITLE
Associative property broken #108

### DIFF
--- a/libs/calc-arithmetic/src/lib/positional/complement-extension.spec.ts
+++ b/libs/calc-arithmetic/src/lib/positional/complement-extension.spec.ts
@@ -1,4 +1,4 @@
-import { hasInfiniteExtension, mergeExtensionDigits } from './complement-extension';
+import { extendComplement, hasInfiniteExtension, mergeExtensionDigits } from './complement-extension';
 import { AdditionOperand, AdditionPositionResult, Digit } from '../models';
 
 
@@ -467,44 +467,20 @@ describe('complement-extension', () => {
     });
 
     describe('#mergeExtensionDigits', () => {
-        it('should return proper digit array when there are some extension digits', () => {
+        it('should return initial digit array when array num of digits in array is less than 3', () => {
             // given
-            const resultDigits: AdditionOperand[] = [
-                {
-                    position: 5,
-                    base: 10,
-                    representationInBase: '1',
-                    valueInDecimal: 1,
-                    carrySourcePosition: 4
-                },
+            const resultDigits: Digit[] = [
                 {
                     base: 10,
-                    representationInBase: '0',
+                    representationInBase: '(0)',
                     valueInDecimal: 0,
-                    position: 4
-                },
-                {
-                    base: 10,
-                    representationInBase: '0',
-                    valueInDecimal: 0,
-                    position: 3
+                    position: 1,
+                    isComplementExtension: true
                 },
                 {
                     base: 10,
                     representationInBase: '1',
                     valueInDecimal: 1,
-                    position: 2
-                },
-                {
-                    base: 10,
-                    representationInBase: '9',
-                    valueInDecimal: 9,
-                    position: 1
-                },
-                {
-                    base: 10,
-                    representationInBase: '4',
-                    valueInDecimal: 4,
                     position: 0
                 }
             ];
@@ -513,13 +489,19 @@ describe('complement-extension', () => {
             const result = mergeExtensionDigits(resultDigits);
 
             // then
-            const expected: AdditionOperand[] = [
+            const expected: Digit[] = [...resultDigits];
+            expect(result).toEqual(expected);
+        });
+
+        it('should return initial digit array when there is only one extension digit', () => {
+            // given
+            const resultDigits: Digit[] = [
                 {
                     base: 10,
                     representationInBase: '(0)',
-                    isComplementExtension: true,
                     valueInDecimal: 0,
-                    position: 3
+                    position: 3,
+                    isComplementExtension: true
                 },
                 {
                     base: 10,
@@ -529,17 +511,23 @@ describe('complement-extension', () => {
                 },
                 {
                     base: 10,
-                    representationInBase: '9',
-                    valueInDecimal: 9,
+                    representationInBase: '5',
+                    valueInDecimal: 5,
                     position: 1
                 },
                 {
                     base: 10,
-                    representationInBase: '4',
-                    valueInDecimal: 4,
+                    representationInBase: '6',
+                    valueInDecimal: 6,
                     position: 0
                 }
             ];
+
+            // when
+            const result = mergeExtensionDigits(resultDigits);
+
+            // then
+            const expected: Digit[] = [...resultDigits];
             expect(result).toEqual(expected);
         });
 
@@ -549,7 +537,7 @@ describe('complement-extension', () => {
                 { base: 8, representationInBase: '(0)', valueInDecimal: 0, position: 3, isComplementExtension: true },
                 { base: 8, representationInBase: '0', valueInDecimal: 0, position: 2 },
                 { base: 8, representationInBase: '2', valueInDecimal: 2, position: 1 },
-                { base: 8, representationInBase: '3', valueInDecimal: 3, position: 0 },
+                { base: 8, representationInBase: '3', valueInDecimal: 3, position: 0 }
             ];
 
             // when
@@ -559,7 +547,7 @@ describe('complement-extension', () => {
             const expected: Digit[] = [
                 { base: 8, representationInBase: '(0)', valueInDecimal: 0, position: 2, isComplementExtension: true },
                 { base: 8, representationInBase: '2', valueInDecimal: 2, position: 1 },
-                { base: 8, representationInBase: '3', valueInDecimal: 3, position: 0 },
+                { base: 8, representationInBase: '3', valueInDecimal: 3, position: 0 }
             ];
 
             expect(result).toEqual(expected);
@@ -607,6 +595,32 @@ describe('complement-extension', () => {
                     position: 0
                 }
             ];
+            expect(result).toEqual(expected);
+        });
+    });
+
+    describe('#extendComplement', () => {
+        it('should return digit array with complement extended to number of positions', () => {
+            // given
+            const digits: Digit[] = [
+                { base: 8, representationInBase: '(0)', valueInDecimal: 0, position: 2, isComplementExtension: true },
+                { base: 8, representationInBase: '2', valueInDecimal: 2, position: 1 },
+                { base: 8, representationInBase: '3', valueInDecimal: 3, position: 0 }
+            ];
+
+            // when
+            const numPositions = 3;
+            const result = extendComplement(digits, numPositions);
+
+            // then
+            const expected: Digit[] = [
+                { base: 8, representationInBase: '(0)', valueInDecimal: 0, position: 4, isComplementExtension: true },
+                { base: 8, representationInBase: '0', valueInDecimal: 0, position: 3, isComplementExtension: false },
+                { base: 8, representationInBase: '0', valueInDecimal: 0, position: 2, isComplementExtension: false },
+                { base: 8, representationInBase: '2', valueInDecimal: 2, position: 1 },
+                { base: 8, representationInBase: '3', valueInDecimal: 3, position: 0 }
+            ];
+
             expect(result).toEqual(expected);
         });
     });

--- a/libs/calc-arithmetic/src/lib/positional/complement-extension.ts
+++ b/libs/calc-arithmetic/src/lib/positional/complement-extension.ts
@@ -30,9 +30,14 @@ function hasSingleCarryFromPreviousPosition(curr: AdditionPositionResult): boole
 }
 
 export function mergeExtensionDigits<T extends Digit>(resultDigits: T[]): T[] {
-    const [, extensionDigit, ...rest] = resultDigits;
+    if(resultDigits.length < 2) return resultDigits;
+
+    const [extension, firstNonExtension, ...rest] = resultDigits;
+    const hasDigitsToMerge = extension.valueInDecimal === firstNonExtension.valueInDecimal;
+    if(!hasDigitsToMerge) return resultDigits;
+
     const firstDifferentIndex = rest.findIndex((digit) => {
-        return digit.valueInDecimal != extensionDigit.valueInDecimal;
+        return digit.valueInDecimal != firstNonExtension.valueInDecimal;
     });
 
     const startPositionIndex = firstDifferentIndex === -1
@@ -40,7 +45,7 @@ export function mergeExtensionDigits<T extends Digit>(resultDigits: T[]): T[] {
         : firstDifferentIndex;
 
     const startPosition = rest[startPositionIndex].position;
-    const mergedExtension = getComplementExtension(extensionDigit, startPosition + 1);
+    const mergedExtension = getComplementExtension(firstNonExtension, startPosition + 1);
     const nonExtensionDigits = rest.slice(firstDifferentIndex);
 
     return [mergedExtension, ...nonExtensionDigits]

--- a/libs/calc-arithmetic/src/lib/positional/multiplication/multiplication-with-extension.spec.ts
+++ b/libs/calc-arithmetic/src/lib/positional/multiplication/multiplication-with-extension.spec.ts
@@ -81,7 +81,6 @@ describe('multiply-with-extensions', () => {
             expect(result.numberResult.complement.toString()).toEqual(expectedComplement);
         });
 
-
         it('should multiply two negative numbers', () => {
             // given
             const base = 10;
@@ -94,6 +93,22 @@ describe('multiply-with-extensions', () => {
             // then
             const expected = '6864';
             expect(result.numberResult.toString()).toEqual(expected);
+        });
+
+        it('should follow associative property of multiplication', () => {
+            // given
+            const base = 10;
+            const x = fromStringDirect('-88', base).result;
+            const y = fromStringDirect('78', base).result;
+
+            // when
+            const xy = multiplyWithExtensions([x, y]);
+            const yx = multiplyWithExtensions([y, x]);
+
+            // then
+            const expected = '-6864';
+            expect(xy.numberResult.toString()).toEqual(expected);
+            expect(yx.numberResult.toString()).toEqual(expected);
         });
     });
 });

--- a/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
+++ b/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
@@ -68,7 +68,7 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
 
     const [operands, setOperands] = useState<DndOperand[]>(
         defaultOperands ||
-        [{valid: true, representation: '(9)22', dndKey: '1'}, {valid: true, representation: '(9)12', dndKey: '2'}]
+        [{valid: true, representation: '78', dndKey: '1'}, {valid: true, representation: '-88', dndKey: '2'}]
     );
     const [canAddOperand, setCanAddOperand] = useState(true);
     const [canCalculate, setCanCalculate] = useState(false);


### PR DESCRIPTION
- RC: row result for multiplication was correct
  but after series complement shifts, merges and
  extensions, the result used for addition was
  wrong. This in turn was caused by incorrect
  extension merge for cases where's only one
  extension digit
- remove old tests for mergeExtension as this
  test related to addition, and addition now uses
  separate function for merging results
  
  closes #108 