### PR TITLE
Cannot download grid result

### DIFF
--- a/apps/calc-web-e2e/.gitignore
+++ b/apps/calc-web-e2e/.gitignore
@@ -1,0 +1,2 @@
+downloads/
+!downloads/.gitkeep

--- a/apps/calc-web-e2e/__snapshots__/index.js.snap
+++ b/apps/calc-web-e2e/__snapshots__/index.js.snap
@@ -444,243 +444,237 @@ exports[`Base converter conversion > should convert to another base when number 
 `;
 
 exports[`Base converter conversion > should convert to another base when number has no fraction part #1`] = `
-<div class="makeStyles-gridWrapper-96" id="integral-conversion-grid">
-  <div>
-    <div class="makeStyles-cellBox-97">
-      <div class="makeStyles-cellContent-98">
-        <div class="makeStyles-gridRow-95">
-          <div
-            data-test="integral-conversion-grid-0-0"
-            class="makeStyles-defaultCell-103"
-          >
-            1
-          </div>
-          <div
-            data-test="integral-conversion-grid-1-0"
-            class="makeStyles-defaultCell-103"
-          >
-            2
-          </div>
-          <div
-            data-test="integral-conversion-grid-2-0"
-            class="makeStyles-defaultCell-103 makeStyles-verticalLine-110"
-          >
-            3
-          </div>
-          <div
-            data-test="integral-conversion-grid-3-0"
-            class="makeStyles-defaultCell-103"
-          >
-            6
-          </div>
-          <div
-            data-test="integral-conversion-grid-4-0"
-            class="makeStyles-defaultCell-103"
-          >
-            1
-          </div>
-          <div
-            data-test="integral-conversion-grid-5-0"
-            class="makeStyles-defaultCell-103"
-          ></div>
-          <div
-            data-test="integral-conversion-grid-6-0"
-            class="makeStyles-highlightedCell-107"
-          >
-            1
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-95">
-          <div
-            data-test="integral-conversion-grid-0-1"
-            class="makeStyles-defaultCell-103"
-          ></div>
-          <div
-            data-test="integral-conversion-grid-1-1"
-            class="makeStyles-defaultCell-103"
-          >
-            6
-          </div>
-          <div
-            data-test="integral-conversion-grid-2-1"
-            class="makeStyles-defaultCell-103 makeStyles-verticalLine-110"
-          >
-            1
-          </div>
-          <div
-            data-test="integral-conversion-grid-3-1"
-            class="makeStyles-defaultCell-103"
-          >
-            3
-          </div>
-          <div
-            data-test="integral-conversion-grid-4-1"
-            class="makeStyles-defaultCell-103"
-          >
-            0
-          </div>
-          <div
-            data-test="integral-conversion-grid-5-1"
-            class="makeStyles-defaultCell-103"
-          ></div>
-          <div
-            data-test="integral-conversion-grid-6-1"
-            class="makeStyles-highlightedCell-107"
-          >
-            1
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-95">
-          <div
-            data-test="integral-conversion-grid-0-2"
-            class="makeStyles-defaultCell-103"
-          ></div>
-          <div
-            data-test="integral-conversion-grid-1-2"
-            class="makeStyles-defaultCell-103"
-          >
-            3
-          </div>
-          <div
-            data-test="integral-conversion-grid-2-2"
-            class="makeStyles-defaultCell-103 makeStyles-verticalLine-110"
-          >
-            0
-          </div>
-          <div
-            data-test="integral-conversion-grid-3-2"
-            class="makeStyles-defaultCell-103"
-          >
-            1
-          </div>
-          <div
-            data-test="integral-conversion-grid-4-2"
-            class="makeStyles-defaultCell-103"
-          >
-            5
-          </div>
-          <div
-            data-test="integral-conversion-grid-5-2"
-            class="makeStyles-defaultCell-103"
-          ></div>
-          <div
-            data-test="integral-conversion-grid-6-2"
-            class="makeStyles-highlightedCell-107"
-          >
-            0
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-95">
-          <div
-            data-test="integral-conversion-grid-0-3"
-            class="makeStyles-defaultCell-103"
-          ></div>
-          <div
-            data-test="integral-conversion-grid-1-3"
-            class="makeStyles-defaultCell-103"
-          >
-            1
-          </div>
-          <div
-            data-test="integral-conversion-grid-2-3"
-            class="makeStyles-defaultCell-103 makeStyles-verticalLine-110"
-          >
-            5
-          </div>
-          <div
-            data-test="integral-conversion-grid-3-3"
-            class="makeStyles-defaultCell-103"
-          >
-            7
-          </div>
-          <div
-            data-test="integral-conversion-grid-4-3"
-            class="makeStyles-defaultCell-103"
-          ></div>
-          <div
-            data-test="integral-conversion-grid-5-3"
-            class="makeStyles-defaultCell-103"
-          ></div>
-          <div
-            data-test="integral-conversion-grid-6-3"
-            class="makeStyles-highlightedCell-107"
-          >
-            1
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-95">
-          <div
-            data-test="integral-conversion-grid-0-4"
-            class="makeStyles-defaultCell-103"
-          ></div>
-          <div
-            data-test="integral-conversion-grid-1-4"
-            class="makeStyles-defaultCell-103"
-          ></div>
-          <div
-            data-test="integral-conversion-grid-2-4"
-            class="makeStyles-defaultCell-103 makeStyles-verticalLine-110"
-          >
-            7
-          </div>
-          <div
-            data-test="integral-conversion-grid-3-4"
-            class="makeStyles-defaultCell-103"
-          >
-            3
-          </div>
-          <div
-            data-test="integral-conversion-grid-4-4"
-            class="makeStyles-defaultCell-103"
-          ></div>
-          <div
-            data-test="integral-conversion-grid-5-4"
-            class="makeStyles-defaultCell-103"
-          ></div>
-          <div
-            data-test="integral-conversion-grid-6-4"
-            class="makeStyles-highlightedCell-107"
-          >
-            1
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-95">
-          <div
-            data-test="integral-conversion-grid-0-5"
-            class="makeStyles-defaultCell-103"
-          ></div>
-          <div
-            data-test="integral-conversion-grid-1-5"
-            class="makeStyles-defaultCell-103"
-          ></div>
-          <div
-            data-test="integral-conversion-grid-2-5"
-            class="makeStyles-defaultCell-103 makeStyles-verticalLine-110"
-          >
-            3
-          </div>
-          <div
-            data-test="integral-conversion-grid-3-5"
-            class="makeStyles-highlightedCell-107"
-          >
-            1
-          </div>
-          <div
-            data-test="integral-conversion-grid-4-5"
-            class="makeStyles-highlightedCell-107"
-          ></div>
-          <div
-            data-test="integral-conversion-grid-5-5"
-            class="makeStyles-highlightedCell-107"
-          ></div>
-          <div
-            data-test="integral-conversion-grid-6-5"
-            class="makeStyles-highlightedCell-107"
-          >
-            1
-          </div>
-        </div>
-      </div>
+<div class="makeStyles-cellContent-98" id="integral-conversion-grid">
+  <div class="makeStyles-gridRow-95">
+    <div
+      data-test="integral-conversion-grid-0-0"
+      class="makeStyles-defaultCell-103"
+    >
+      1
+    </div>
+    <div
+      data-test="integral-conversion-grid-1-0"
+      class="makeStyles-defaultCell-103"
+    >
+      2
+    </div>
+    <div
+      data-test="integral-conversion-grid-2-0"
+      class="makeStyles-defaultCell-103 makeStyles-verticalLine-110"
+    >
+      3
+    </div>
+    <div
+      data-test="integral-conversion-grid-3-0"
+      class="makeStyles-defaultCell-103"
+    >
+      6
+    </div>
+    <div
+      data-test="integral-conversion-grid-4-0"
+      class="makeStyles-defaultCell-103"
+    >
+      1
+    </div>
+    <div
+      data-test="integral-conversion-grid-5-0"
+      class="makeStyles-defaultCell-103"
+    ></div>
+    <div
+      data-test="integral-conversion-grid-6-0"
+      class="makeStyles-highlightedCell-107"
+    >
+      1
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-95">
+    <div
+      data-test="integral-conversion-grid-0-1"
+      class="makeStyles-defaultCell-103"
+    ></div>
+    <div
+      data-test="integral-conversion-grid-1-1"
+      class="makeStyles-defaultCell-103"
+    >
+      6
+    </div>
+    <div
+      data-test="integral-conversion-grid-2-1"
+      class="makeStyles-defaultCell-103 makeStyles-verticalLine-110"
+    >
+      1
+    </div>
+    <div
+      data-test="integral-conversion-grid-3-1"
+      class="makeStyles-defaultCell-103"
+    >
+      3
+    </div>
+    <div
+      data-test="integral-conversion-grid-4-1"
+      class="makeStyles-defaultCell-103"
+    >
+      0
+    </div>
+    <div
+      data-test="integral-conversion-grid-5-1"
+      class="makeStyles-defaultCell-103"
+    ></div>
+    <div
+      data-test="integral-conversion-grid-6-1"
+      class="makeStyles-highlightedCell-107"
+    >
+      1
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-95">
+    <div
+      data-test="integral-conversion-grid-0-2"
+      class="makeStyles-defaultCell-103"
+    ></div>
+    <div
+      data-test="integral-conversion-grid-1-2"
+      class="makeStyles-defaultCell-103"
+    >
+      3
+    </div>
+    <div
+      data-test="integral-conversion-grid-2-2"
+      class="makeStyles-defaultCell-103 makeStyles-verticalLine-110"
+    >
+      0
+    </div>
+    <div
+      data-test="integral-conversion-grid-3-2"
+      class="makeStyles-defaultCell-103"
+    >
+      1
+    </div>
+    <div
+      data-test="integral-conversion-grid-4-2"
+      class="makeStyles-defaultCell-103"
+    >
+      5
+    </div>
+    <div
+      data-test="integral-conversion-grid-5-2"
+      class="makeStyles-defaultCell-103"
+    ></div>
+    <div
+      data-test="integral-conversion-grid-6-2"
+      class="makeStyles-highlightedCell-107"
+    >
+      0
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-95">
+    <div
+      data-test="integral-conversion-grid-0-3"
+      class="makeStyles-defaultCell-103"
+    ></div>
+    <div
+      data-test="integral-conversion-grid-1-3"
+      class="makeStyles-defaultCell-103"
+    >
+      1
+    </div>
+    <div
+      data-test="integral-conversion-grid-2-3"
+      class="makeStyles-defaultCell-103 makeStyles-verticalLine-110"
+    >
+      5
+    </div>
+    <div
+      data-test="integral-conversion-grid-3-3"
+      class="makeStyles-defaultCell-103"
+    >
+      7
+    </div>
+    <div
+      data-test="integral-conversion-grid-4-3"
+      class="makeStyles-defaultCell-103"
+    ></div>
+    <div
+      data-test="integral-conversion-grid-5-3"
+      class="makeStyles-defaultCell-103"
+    ></div>
+    <div
+      data-test="integral-conversion-grid-6-3"
+      class="makeStyles-highlightedCell-107"
+    >
+      1
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-95">
+    <div
+      data-test="integral-conversion-grid-0-4"
+      class="makeStyles-defaultCell-103"
+    ></div>
+    <div
+      data-test="integral-conversion-grid-1-4"
+      class="makeStyles-defaultCell-103"
+    ></div>
+    <div
+      data-test="integral-conversion-grid-2-4"
+      class="makeStyles-defaultCell-103 makeStyles-verticalLine-110"
+    >
+      7
+    </div>
+    <div
+      data-test="integral-conversion-grid-3-4"
+      class="makeStyles-defaultCell-103"
+    >
+      3
+    </div>
+    <div
+      data-test="integral-conversion-grid-4-4"
+      class="makeStyles-defaultCell-103"
+    ></div>
+    <div
+      data-test="integral-conversion-grid-5-4"
+      class="makeStyles-defaultCell-103"
+    ></div>
+    <div
+      data-test="integral-conversion-grid-6-4"
+      class="makeStyles-highlightedCell-107"
+    >
+      1
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-95">
+    <div
+      data-test="integral-conversion-grid-0-5"
+      class="makeStyles-defaultCell-103"
+    ></div>
+    <div
+      data-test="integral-conversion-grid-1-5"
+      class="makeStyles-defaultCell-103"
+    ></div>
+    <div
+      data-test="integral-conversion-grid-2-5"
+      class="makeStyles-defaultCell-103 makeStyles-verticalLine-110"
+    >
+      3
+    </div>
+    <div
+      data-test="integral-conversion-grid-3-5"
+      class="makeStyles-highlightedCell-107"
+    >
+      1
+    </div>
+    <div
+      data-test="integral-conversion-grid-4-5"
+      class="makeStyles-highlightedCell-107"
+    ></div>
+    <div
+      data-test="integral-conversion-grid-5-5"
+      class="makeStyles-highlightedCell-107"
+    ></div>
+    <div
+      data-test="integral-conversion-grid-6-5"
+      class="makeStyles-highlightedCell-107"
+    >
+      1
     </div>
   </div>
 </div>
@@ -1123,96 +1117,67 @@ exports[`Addition > should add two decimal numbers together #0`] = `
 `;
 
 exports[`Addition > should add two decimal numbers together #1`] = `
-<div class="makeStyles-gridWrapper-92" id="operation-grid">
-  <div class="makeStyles-indicesBox-95">
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>4</sub></span>
+<div class="makeStyles-cellContent-94" id="operation-grid">
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-0" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-0" class="makeStyles-defaultCell-99">
+      (0)
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>3</sub></span>
+    <div data-test="operation-grid-2-0" class="makeStyles-defaultCell-99">
+      1
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>2</sub></span>
+    <div data-test="operation-grid-3-0" class="makeStyles-defaultCell-99">
+      2
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>1</sub></span>
-    </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>0</sub></span>
+    <div data-test="operation-grid-4-0" class="makeStyles-defaultCell-99">
+      3
     </div>
   </div>
-  <div>
-    <div class="makeStyles-cellBox-93">
-      <div class="makeStyles-cellContent-94">
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div data-test="operation-grid-1-0" class="makeStyles-defaultCell-99">
-            (0)
-          </div>
-          <div data-test="operation-grid-2-0" class="makeStyles-defaultCell-99">
-            1
-          </div>
-          <div data-test="operation-grid-3-0" class="makeStyles-defaultCell-99">
-            2
-          </div>
-          <div data-test="operation-grid-4-0" class="makeStyles-defaultCell-99">
-            3
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            +
-          </div>
-          <div
-            data-test="operation-grid-1-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            (0)
-          </div>
-          <div
-            data-test="operation-grid-2-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            3
-          </div>
-          <div
-            data-test="operation-grid-3-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-4-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            1
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-2"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div data-test="operation-grid-1-2" class="makeStyles-defaultCell-99">
-            (0)
-          </div>
-          <div data-test="operation-grid-2-2" class="makeStyles-defaultCell-99">
-            4
-          </div>
-          <div data-test="operation-grid-3-2" class="makeStyles-defaultCell-99">
-            4
-          </div>
-          <div data-test="operation-grid-4-2" class="makeStyles-defaultCell-99">
-            4
-          </div>
-        </div>
-      </div>
+  <div class="makeStyles-gridRow-91">
+    <div
+      data-test="operation-grid-0-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      +
+    </div>
+    <div
+      data-test="operation-grid-1-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      (0)
+    </div>
+    <div
+      data-test="operation-grid-2-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      3
+    </div>
+    <div
+      data-test="operation-grid-3-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      2
+    </div>
+    <div
+      data-test="operation-grid-4-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      1
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-2" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-2" class="makeStyles-defaultCell-99">
+      (0)
+    </div>
+    <div data-test="operation-grid-2-2" class="makeStyles-defaultCell-99">
+      4
+    </div>
+    <div data-test="operation-grid-3-2" class="makeStyles-defaultCell-99">
+      4
+    </div>
+    <div data-test="operation-grid-4-2" class="makeStyles-defaultCell-99">
+      4
     </div>
   </div>
 </div>
@@ -2383,895 +2348,554 @@ exports[`Addition > should add multiple binary numbers together #0`] = `
 `;
 
 exports[`Addition > should add multiple binary numbers together #1`] = `
-<div class="makeStyles-gridWrapper-92" id="operation-grid">
-  <div class="makeStyles-indicesBox-95">
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>18</sub></span>
+<div class="makeStyles-cellContent-94" id="operation-grid">
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-0" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-0" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-2-0" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-3-0" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-4-0" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-5-0" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-6-0" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-7-0" class="makeStyles-defaultCell-99">
+      <div>1<sub style="font-size: 8px;">10</sub></div>
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>17</sub></span>
+    <div data-test="operation-grid-8-0" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-9-0" class="makeStyles-defaultCell-99"></div>
+    <div
+      data-test="operation-grid-10-0"
+      class="makeStyles-defaultCell-99"
+    ></div>
+    <div
+      data-test="operation-grid-11-0"
+      class="makeStyles-defaultCell-99"
+    ></div>
+    <div
+      data-test="operation-grid-12-0"
+      class="makeStyles-defaultCell-99"
+    ></div>
+    <div
+      data-test="operation-grid-13-0"
+      class="makeStyles-defaultCell-99"
+    ></div>
+    <div
+      data-test="operation-grid-14-0"
+      class="makeStyles-defaultCell-99"
+    ></div>
+    <div
+      data-test="operation-grid-15-0"
+      class="makeStyles-defaultCell-99"
+    ></div>
+    <div
+      data-test="operation-grid-16-0"
+      class="makeStyles-defaultCell-99"
+    ></div>
+    <div
+      data-test="operation-grid-17-0"
+      class="makeStyles-defaultCell-99"
+    ></div>
+    <div
+      data-test="operation-grid-18-0"
+      class="makeStyles-defaultCell-99"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-1" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-1" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-2-1" class="makeStyles-defaultCell-99"></div>
+    <div
+      data-test="operation-grid-3-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      <div>1<sub style="font-size: 8px;">14</sub></div>
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>16</sub></span>
+    <div
+      data-test="operation-grid-4-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      <div>1<sub style="font-size: 8px;">13</sub></div>
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>15</sub></span>
+    <div
+      data-test="operation-grid-5-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      <div>1<sub style="font-size: 8px;">11</sub></div>
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>14</sub></span>
+    <div
+      data-test="operation-grid-6-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    ></div>
+    <div
+      data-test="operation-grid-7-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      <div>1<sub style="font-size: 8px;">9</sub></div>
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>13</sub></span>
+    <div
+      data-test="operation-grid-8-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      <div>1<sub style="font-size: 8px;">8</sub></div>
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>12</sub></span>
+    <div
+      data-test="operation-grid-9-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      <div>1<sub style="font-size: 8px;">7</sub></div>
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>11</sub></span>
+    <div
+      data-test="operation-grid-10-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      <div>1<sub style="font-size: 8px;">6</sub></div>
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>10</sub></span>
+    <div
+      data-test="operation-grid-11-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      <div>1<sub style="font-size: 8px;">5</sub></div>
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>9</sub></span>
+    <div
+      data-test="operation-grid-12-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      <div>1<sub style="font-size: 8px;">4</sub></div>
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>8</sub></span>
+    <div
+      data-test="operation-grid-13-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      <div>1<sub style="font-size: 8px;">3</sub></div>
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>7</sub></span>
+    <div
+      data-test="operation-grid-14-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      <div>1<sub style="font-size: 8px;">2</sub></div>
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>6</sub></span>
+    <div
+      data-test="operation-grid-15-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      <div>1<sub style="font-size: 8px;">1</sub></div>
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>5</sub></span>
+    <div
+      data-test="operation-grid-16-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      <div>1<sub style="font-size: 8px;">0</sub></div>
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>4</sub></span>
+    <div
+      data-test="operation-grid-17-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      <div>1<sub style="font-size: 8px;">0</sub></div>
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>3</sub></span>
+    <div
+      data-test="operation-grid-18-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-2" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-2" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-2-2" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-3-2" class="makeStyles-defaultCell-99">
+      (0)
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>2</sub></span>
+    <div data-test="operation-grid-4-2" class="makeStyles-defaultCell-99">
+      1
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>1</sub></span>
+    <div data-test="operation-grid-5-2" class="makeStyles-defaultCell-99">
+      0
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>0</sub></span>
+    <div data-test="operation-grid-6-2" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-7-2" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-8-2" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-9-2" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-10-2" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-11-2" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-12-2" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-13-2" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-14-2" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-15-2" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-16-2" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-17-2" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-18-2" class="makeStyles-defaultCell-99">
+      1
     </div>
   </div>
-  <div>
-    <div class="makeStyles-cellBox-93">
-      <div class="makeStyles-cellContent-94">
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-1-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-2-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-3-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-4-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-5-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-6-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div data-test="operation-grid-7-0" class="makeStyles-defaultCell-99">
-            <div>1<sub style="font-size: 8px;">10</sub></div>
-          </div>
-          <div
-            data-test="operation-grid-8-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-9-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-10-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-11-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-12-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-13-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-14-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-15-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-16-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-17-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-18-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-1"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-1-1"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-2-1"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-3-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            <div>1<sub style="font-size: 8px;">14</sub></div>
-          </div>
-          <div
-            data-test="operation-grid-4-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            <div>1<sub style="font-size: 8px;">13</sub></div>
-          </div>
-          <div
-            data-test="operation-grid-5-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            <div>1<sub style="font-size: 8px;">11</sub></div>
-          </div>
-          <div
-            data-test="operation-grid-6-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          ></div>
-          <div
-            data-test="operation-grid-7-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            <div>1<sub style="font-size: 8px;">9</sub></div>
-          </div>
-          <div
-            data-test="operation-grid-8-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            <div>1<sub style="font-size: 8px;">8</sub></div>
-          </div>
-          <div
-            data-test="operation-grid-9-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            <div>1<sub style="font-size: 8px;">7</sub></div>
-          </div>
-          <div
-            data-test="operation-grid-10-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            <div>1<sub style="font-size: 8px;">6</sub></div>
-          </div>
-          <div
-            data-test="operation-grid-11-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            <div>1<sub style="font-size: 8px;">5</sub></div>
-          </div>
-          <div
-            data-test="operation-grid-12-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            <div>1<sub style="font-size: 8px;">4</sub></div>
-          </div>
-          <div
-            data-test="operation-grid-13-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            <div>1<sub style="font-size: 8px;">3</sub></div>
-          </div>
-          <div
-            data-test="operation-grid-14-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            <div>1<sub style="font-size: 8px;">2</sub></div>
-          </div>
-          <div
-            data-test="operation-grid-15-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            <div>1<sub style="font-size: 8px;">1</sub></div>
-          </div>
-          <div
-            data-test="operation-grid-16-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            <div>1<sub style="font-size: 8px;">0</sub></div>
-          </div>
-          <div
-            data-test="operation-grid-17-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            <div>1<sub style="font-size: 8px;">0</sub></div>
-          </div>
-          <div
-            data-test="operation-grid-18-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          ></div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-2"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-1-2"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-2-2"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div data-test="operation-grid-3-2" class="makeStyles-defaultCell-99">
-            (0)
-          </div>
-          <div data-test="operation-grid-4-2" class="makeStyles-defaultCell-99">
-            1
-          </div>
-          <div data-test="operation-grid-5-2" class="makeStyles-defaultCell-99">
-            0
-          </div>
-          <div data-test="operation-grid-6-2" class="makeStyles-defaultCell-99">
-            0
-          </div>
-          <div data-test="operation-grid-7-2" class="makeStyles-defaultCell-99">
-            1
-          </div>
-          <div data-test="operation-grid-8-2" class="makeStyles-defaultCell-99">
-            0
-          </div>
-          <div data-test="operation-grid-9-2" class="makeStyles-defaultCell-99">
-            1
-          </div>
-          <div
-            data-test="operation-grid-10-2"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-11-2"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-12-2"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-13-2"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-14-2"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-15-2"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-16-2"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-17-2"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-18-2"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-3"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-1-3"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-2-3"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-3-3"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-4-3"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div data-test="operation-grid-5-3" class="makeStyles-defaultCell-99">
-            (0)
-          </div>
-          <div data-test="operation-grid-6-3" class="makeStyles-defaultCell-99">
-            1
-          </div>
-          <div data-test="operation-grid-7-3" class="makeStyles-defaultCell-99">
-            1
-          </div>
-          <div data-test="operation-grid-8-3" class="makeStyles-defaultCell-99">
-            0
-          </div>
-          <div data-test="operation-grid-9-3" class="makeStyles-defaultCell-99">
-            1
-          </div>
-          <div
-            data-test="operation-grid-10-3"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-11-3"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-12-3"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-13-3"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-14-3"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-15-3"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-16-3"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-17-3"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-18-3"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-4"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div data-test="operation-grid-1-4" class="makeStyles-defaultCell-99">
-            (1)
-          </div>
-          <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-99">
-            0
-          </div>
-          <div data-test="operation-grid-3-4" class="makeStyles-defaultCell-99">
-            0
-          </div>
-          <div data-test="operation-grid-4-4" class="makeStyles-defaultCell-99">
-            0
-          </div>
-          <div data-test="operation-grid-5-4" class="makeStyles-defaultCell-99">
-            1
-          </div>
-          <div data-test="operation-grid-6-4" class="makeStyles-defaultCell-99">
-            0
-          </div>
-          <div data-test="operation-grid-7-4" class="makeStyles-defaultCell-99">
-            0
-          </div>
-          <div data-test="operation-grid-8-4" class="makeStyles-defaultCell-99">
-            1
-          </div>
-          <div data-test="operation-grid-9-4" class="makeStyles-defaultCell-99">
-            0
-          </div>
-          <div
-            data-test="operation-grid-10-4"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-11-4"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-12-4"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-13-4"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-14-4"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-15-4"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-16-4"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-17-4"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-18-4"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-5"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-1-5"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-2-5"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-3-5"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-4-5"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-5-5"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-6-5"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-7-5"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-8-5"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div data-test="operation-grid-9-5" class="makeStyles-defaultCell-99">
-            (0)
-          </div>
-          <div
-            data-test="operation-grid-10-5"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-11-5"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-12-5"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-13-5"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-14-5"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-15-5"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-16-5"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-17-5"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-18-5"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-6"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-1-6"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-2-6"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-3-6"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-4-6"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-5-6"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-6-6"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div data-test="operation-grid-7-6" class="makeStyles-defaultCell-99">
-            (0)
-          </div>
-          <div data-test="operation-grid-8-6" class="makeStyles-defaultCell-99">
-            1
-          </div>
-          <div data-test="operation-grid-9-6" class="makeStyles-defaultCell-99">
-            1
-          </div>
-          <div
-            data-test="operation-grid-10-6"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-11-6"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-12-6"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-13-6"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-14-6"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-15-6"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-16-6"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-17-6"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-18-6"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            +
-          </div>
-          <div
-            data-test="operation-grid-1-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          ></div>
-          <div
-            data-test="operation-grid-2-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          ></div>
-          <div
-            data-test="operation-grid-3-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          ></div>
-          <div
-            data-test="operation-grid-4-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          ></div>
-          <div
-            data-test="operation-grid-5-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          ></div>
-          <div
-            data-test="operation-grid-6-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          ></div>
-          <div
-            data-test="operation-grid-7-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          ></div>
-          <div
-            data-test="operation-grid-8-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          ></div>
-          <div
-            data-test="operation-grid-9-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            (0)
-          </div>
-          <div
-            data-test="operation-grid-10-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-11-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-12-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-13-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-14-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-15-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-16-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-17-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-18-7"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            1
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-8"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div data-test="operation-grid-1-8" class="makeStyles-defaultCell-99">
-            (1)
-          </div>
-          <div data-test="operation-grid-2-8" class="makeStyles-defaultCell-99">
-            0
-          </div>
-          <div data-test="operation-grid-3-8" class="makeStyles-defaultCell-99">
-            1
-          </div>
-          <div data-test="operation-grid-4-8" class="makeStyles-defaultCell-99">
-            0
-          </div>
-          <div data-test="operation-grid-5-8" class="makeStyles-defaultCell-99">
-            0
-          </div>
-          <div data-test="operation-grid-6-8" class="makeStyles-defaultCell-99">
-            1
-          </div>
-          <div data-test="operation-grid-7-8" class="makeStyles-defaultCell-99">
-            0
-          </div>
-          <div data-test="operation-grid-8-8" class="makeStyles-defaultCell-99">
-            1
-          </div>
-          <div data-test="operation-grid-9-8" class="makeStyles-defaultCell-99">
-            0
-          </div>
-          <div
-            data-test="operation-grid-10-8"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-11-8"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-12-8"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-13-8"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-14-8"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-15-8"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-16-8"
-            class="makeStyles-defaultCell-99"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-17-8"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-18-8"
-            class="makeStyles-defaultCell-99"
-          >
-            0
-          </div>
-        </div>
-      </div>
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-3" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-3" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-3-3" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-4-3" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-5-3" class="makeStyles-defaultCell-99">
+      (0)
+    </div>
+    <div data-test="operation-grid-6-3" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-7-3" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-8-3" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-9-3" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-10-3" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-11-3" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-12-3" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-13-3" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-14-3" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-15-3" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-16-3" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-17-3" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-18-3" class="makeStyles-defaultCell-99">
+      1
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-4" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-4" class="makeStyles-defaultCell-99">
+      (1)
+    </div>
+    <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-3-4" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-4-4" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-5-4" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-6-4" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-7-4" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-8-4" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-9-4" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-10-4" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-11-4" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-12-4" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-13-4" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-14-4" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-15-4" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-16-4" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-17-4" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-18-4" class="makeStyles-defaultCell-99">
+      1
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-5" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-5" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-2-5" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-3-5" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-4-5" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-5-5" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-6-5" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-7-5" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-8-5" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-9-5" class="makeStyles-defaultCell-99">
+      (0)
+    </div>
+    <div data-test="operation-grid-10-5" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-11-5" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-12-5" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-13-5" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-14-5" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-15-5" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-16-5" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-17-5" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-18-5" class="makeStyles-defaultCell-99">
+      1
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-6" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-6" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-2-6" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-3-6" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-4-6" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-5-6" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-6-6" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-7-6" class="makeStyles-defaultCell-99">
+      (0)
+    </div>
+    <div data-test="operation-grid-8-6" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-9-6" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-10-6" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-11-6" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-12-6" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-13-6" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-14-6" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-15-6" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-16-6" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-17-6" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-18-6" class="makeStyles-defaultCell-99">
+      1
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-91">
+    <div
+      data-test="operation-grid-0-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      +
+    </div>
+    <div
+      data-test="operation-grid-1-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    ></div>
+    <div
+      data-test="operation-grid-2-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    ></div>
+    <div
+      data-test="operation-grid-3-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    ></div>
+    <div
+      data-test="operation-grid-4-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    ></div>
+    <div
+      data-test="operation-grid-5-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    ></div>
+    <div
+      data-test="operation-grid-6-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    ></div>
+    <div
+      data-test="operation-grid-7-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    ></div>
+    <div
+      data-test="operation-grid-8-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    ></div>
+    <div
+      data-test="operation-grid-9-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      (0)
+    </div>
+    <div
+      data-test="operation-grid-10-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      1
+    </div>
+    <div
+      data-test="operation-grid-11-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      1
+    </div>
+    <div
+      data-test="operation-grid-12-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-13-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      1
+    </div>
+    <div
+      data-test="operation-grid-14-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      1
+    </div>
+    <div
+      data-test="operation-grid-15-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      1
+    </div>
+    <div
+      data-test="operation-grid-16-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-17-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      1
+    </div>
+    <div
+      data-test="operation-grid-18-7"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      1
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-8" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-8" class="makeStyles-defaultCell-99">
+      (1)
+    </div>
+    <div data-test="operation-grid-2-8" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-3-8" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-4-8" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-5-8" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-6-8" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-7-8" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-8-8" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-9-8" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-10-8" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-11-8" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-12-8" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-13-8" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-14-8" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-15-8" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-16-8" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-17-8" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-18-8" class="makeStyles-defaultCell-99">
+      0
     </div>
   </div>
 </div>
@@ -3460,146 +3084,119 @@ exports[`Default multiplication > should multiply two positive numbers #0`] = `
 `;
 
 exports[`Default multiplication > should multiply two positive numbers #1`] = `
-<div class="makeStyles-gridWrapper-91" id="operation-grid">
-  <div>
-    <div class="makeStyles-cellBox-92">
-      <div class="makeStyles-cellContent-93">
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-1-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-2-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-3-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-4-0" class="makeStyles-defaultCell-98">
-            7
-          </div>
-          <div data-test="operation-grid-5-0" class="makeStyles-defaultCell-98">
-            8
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            *
-          </div>
-          <div
-            data-test="operation-grid-1-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-2-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-3-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-4-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            8
-          </div>
-          <div
-            data-test="operation-grid-5-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            8
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-2"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-1-2"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-2-2" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-3-2" class="makeStyles-defaultCell-98">
-            6
-          </div>
-          <div data-test="operation-grid-4-2" class="makeStyles-defaultCell-98">
-            2
-          </div>
-          <div data-test="operation-grid-5-2" class="makeStyles-defaultCell-98">
-            4
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            +
-          </div>
-          <div
-            data-test="operation-grid-1-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            (0)
-          </div>
-          <div
-            data-test="operation-grid-2-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            6
-          </div>
-          <div
-            data-test="operation-grid-3-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-4-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            4
-          </div>
-          <div
-            data-test="operation-grid-5-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-4"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-1-4" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-98">
-            6
-          </div>
-          <div data-test="operation-grid-3-4" class="makeStyles-defaultCell-98">
-            8
-          </div>
-          <div data-test="operation-grid-4-4" class="makeStyles-defaultCell-98">
-            6
-          </div>
-          <div data-test="operation-grid-5-4" class="makeStyles-defaultCell-98">
-            4
-          </div>
-        </div>
-      </div>
+<div class="makeStyles-cellContent-93" id="operation-grid">
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-2-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-3-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-4-0" class="makeStyles-defaultCell-98">
+      7
+    </div>
+    <div data-test="operation-grid-5-0" class="makeStyles-defaultCell-98">
+      8
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      *
+    </div>
+    <div
+      data-test="operation-grid-1-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-2-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-3-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-4-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      8
+    </div>
+    <div
+      data-test="operation-grid-5-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      8
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-2" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-2" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-2-2" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-3-2" class="makeStyles-defaultCell-98">
+      6
+    </div>
+    <div data-test="operation-grid-4-2" class="makeStyles-defaultCell-98">
+      2
+    </div>
+    <div data-test="operation-grid-5-2" class="makeStyles-defaultCell-98">
+      4
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      +
+    </div>
+    <div
+      data-test="operation-grid-1-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      (0)
+    </div>
+    <div
+      data-test="operation-grid-2-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      6
+    </div>
+    <div
+      data-test="operation-grid-3-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      2
+    </div>
+    <div
+      data-test="operation-grid-4-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      4
+    </div>
+    <div
+      data-test="operation-grid-5-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-4" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-4" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-98">
+      6
+    </div>
+    <div data-test="operation-grid-3-4" class="makeStyles-defaultCell-98">
+      8
+    </div>
+    <div data-test="operation-grid-4-4" class="makeStyles-defaultCell-98">
+      6
+    </div>
+    <div data-test="operation-grid-5-4" class="makeStyles-defaultCell-98">
+      4
     </div>
   </div>
 </div>
@@ -3788,146 +3385,119 @@ exports[`Default multiplication > should multiply two negative numbers #0`] = `
 `;
 
 exports[`Default multiplication > should multiply two negative numbers #1`] = `
-<div class="makeStyles-gridWrapper-91" id="operation-grid">
-  <div>
-    <div class="makeStyles-cellBox-92">
-      <div class="makeStyles-cellContent-93">
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-1-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-2-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-3-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-4-0" class="makeStyles-defaultCell-98">
-            7
-          </div>
-          <div data-test="operation-grid-5-0" class="makeStyles-defaultCell-98">
-            8
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            *
-          </div>
-          <div
-            data-test="operation-grid-1-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-2-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-3-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-4-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            8
-          </div>
-          <div
-            data-test="operation-grid-5-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            8
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-2"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-1-2"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-2-2" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-3-2" class="makeStyles-defaultCell-98">
-            6
-          </div>
-          <div data-test="operation-grid-4-2" class="makeStyles-defaultCell-98">
-            2
-          </div>
-          <div data-test="operation-grid-5-2" class="makeStyles-defaultCell-98">
-            4
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            +
-          </div>
-          <div
-            data-test="operation-grid-1-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            (0)
-          </div>
-          <div
-            data-test="operation-grid-2-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            6
-          </div>
-          <div
-            data-test="operation-grid-3-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-4-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            4
-          </div>
-          <div
-            data-test="operation-grid-5-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-4"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-1-4" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-98">
-            6
-          </div>
-          <div data-test="operation-grid-3-4" class="makeStyles-defaultCell-98">
-            8
-          </div>
-          <div data-test="operation-grid-4-4" class="makeStyles-defaultCell-98">
-            6
-          </div>
-          <div data-test="operation-grid-5-4" class="makeStyles-defaultCell-98">
-            4
-          </div>
-        </div>
-      </div>
+<div class="makeStyles-cellContent-93" id="operation-grid">
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-2-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-3-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-4-0" class="makeStyles-defaultCell-98">
+      7
+    </div>
+    <div data-test="operation-grid-5-0" class="makeStyles-defaultCell-98">
+      8
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      *
+    </div>
+    <div
+      data-test="operation-grid-1-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-2-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-3-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-4-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      8
+    </div>
+    <div
+      data-test="operation-grid-5-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      8
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-2" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-2" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-2-2" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-3-2" class="makeStyles-defaultCell-98">
+      6
+    </div>
+    <div data-test="operation-grid-4-2" class="makeStyles-defaultCell-98">
+      2
+    </div>
+    <div data-test="operation-grid-5-2" class="makeStyles-defaultCell-98">
+      4
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      +
+    </div>
+    <div
+      data-test="operation-grid-1-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      (0)
+    </div>
+    <div
+      data-test="operation-grid-2-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      6
+    </div>
+    <div
+      data-test="operation-grid-3-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      2
+    </div>
+    <div
+      data-test="operation-grid-4-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      4
+    </div>
+    <div
+      data-test="operation-grid-5-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-4" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-4" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-98">
+      6
+    </div>
+    <div data-test="operation-grid-3-4" class="makeStyles-defaultCell-98">
+      8
+    </div>
+    <div data-test="operation-grid-4-4" class="makeStyles-defaultCell-98">
+      6
+    </div>
+    <div data-test="operation-grid-5-4" class="makeStyles-defaultCell-98">
+      4
     </div>
   </div>
 </div>
@@ -4116,146 +3686,119 @@ exports[`Default multiplication > should multiply negative and positive numbers 
 `;
 
 exports[`Default multiplication > should multiply negative and positive numbers #1`] = `
-<div class="makeStyles-gridWrapper-91" id="operation-grid">
-  <div>
-    <div class="makeStyles-cellBox-92">
-      <div class="makeStyles-cellContent-93">
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-1-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-2-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-3-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-4-0" class="makeStyles-defaultCell-98">
-            7
-          </div>
-          <div data-test="operation-grid-5-0" class="makeStyles-defaultCell-98">
-            8
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            *
-          </div>
-          <div
-            data-test="operation-grid-1-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-2-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-3-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-4-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            8
-          </div>
-          <div
-            data-test="operation-grid-5-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            8
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-2"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-1-2"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-2-2" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-3-2" class="makeStyles-defaultCell-98">
-            6
-          </div>
-          <div data-test="operation-grid-4-2" class="makeStyles-defaultCell-98">
-            2
-          </div>
-          <div data-test="operation-grid-5-2" class="makeStyles-defaultCell-98">
-            4
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            +
-          </div>
-          <div
-            data-test="operation-grid-1-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            (0)
-          </div>
-          <div
-            data-test="operation-grid-2-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            6
-          </div>
-          <div
-            data-test="operation-grid-3-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-4-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            4
-          </div>
-          <div
-            data-test="operation-grid-5-3"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-4"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-1-4" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-98">
-            6
-          </div>
-          <div data-test="operation-grid-3-4" class="makeStyles-defaultCell-98">
-            8
-          </div>
-          <div data-test="operation-grid-4-4" class="makeStyles-defaultCell-98">
-            6
-          </div>
-          <div data-test="operation-grid-5-4" class="makeStyles-defaultCell-98">
-            4
-          </div>
-        </div>
-      </div>
+<div class="makeStyles-cellContent-93" id="operation-grid">
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-2-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-3-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-4-0" class="makeStyles-defaultCell-98">
+      7
+    </div>
+    <div data-test="operation-grid-5-0" class="makeStyles-defaultCell-98">
+      8
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      *
+    </div>
+    <div
+      data-test="operation-grid-1-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-2-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-3-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-4-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      8
+    </div>
+    <div
+      data-test="operation-grid-5-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      8
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-2" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-2" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-2-2" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-3-2" class="makeStyles-defaultCell-98">
+      6
+    </div>
+    <div data-test="operation-grid-4-2" class="makeStyles-defaultCell-98">
+      2
+    </div>
+    <div data-test="operation-grid-5-2" class="makeStyles-defaultCell-98">
+      4
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      +
+    </div>
+    <div
+      data-test="operation-grid-1-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      (0)
+    </div>
+    <div
+      data-test="operation-grid-2-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      6
+    </div>
+    <div
+      data-test="operation-grid-3-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      2
+    </div>
+    <div
+      data-test="operation-grid-4-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      4
+    </div>
+    <div
+      data-test="operation-grid-5-3"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-4" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-4" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-98">
+      6
+    </div>
+    <div data-test="operation-grid-3-4" class="makeStyles-defaultCell-98">
+      8
+    </div>
+    <div data-test="operation-grid-4-4" class="makeStyles-defaultCell-98">
+      6
+    </div>
+    <div data-test="operation-grid-5-4" class="makeStyles-defaultCell-98">
+      4
     </div>
   </div>
 </div>
@@ -4445,373 +3988,179 @@ exports[`Multiplication with extension > should multiply two numbers #0`] = `
 `;
 
 exports[`Multiplication with extension > should multiply two numbers #1`] = `
-<div class="makeStyles-gridWrapper-91" id="operation-grid">
-  <div>
-    <div class="makeStyles-cellBox-92">
-      <div class="makeStyles-cellContent-93">
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-0"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-1-0"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-2-0"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-3-0"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            (9)
-          </div>
-          <div
-            data-test="operation-grid-4-0"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-5-0"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
-          >
-            2
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-1"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-1-1"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-2-1"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-3-1" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-4-1" class="makeStyles-defaultCell-98">
-            7
-          </div>
-          <div
-            data-test="operation-grid-5-1"
-            class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
-          >
-            8
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            *
-          </div>
-          <div
-            data-test="operation-grid-1-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-2-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-3-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            (9)
-          </div>
-          <div
-            data-test="operation-grid-4-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-5-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
-          >
-            2
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-3"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-1-3"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-3-3" class="makeStyles-defaultCell-98">
-            1
-          </div>
-          <div data-test="operation-grid-4-3" class="makeStyles-defaultCell-98">
-            5
-          </div>
-          <div
-            data-test="operation-grid-5-3"
-            class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
-          >
-            6
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-4"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-1-4"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-3-4" class="makeStyles-defaultCell-98">
-            7
-          </div>
-          <div data-test="operation-grid-4-4" class="makeStyles-defaultCell-98">
-            8
-          </div>
-          <div
-            data-test="operation-grid-5-4"
-            class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
-          ></div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-5"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            +
-          </div>
-          <div
-            data-test="operation-grid-1-5"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            (9)
-          </div>
-          <div
-            data-test="operation-grid-2-5"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-3-5"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-4-5"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-5-5"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
-          ></div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-6"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-1-6" class="makeStyles-defaultCell-98">
-            (9)
-          </div>
-          <div data-test="operation-grid-2-6" class="makeStyles-defaultCell-98">
-            3
-          </div>
-          <div data-test="operation-grid-3-6" class="makeStyles-defaultCell-98">
-            1
-          </div>
-          <div data-test="operation-grid-4-6" class="makeStyles-defaultCell-98">
-            3
-          </div>
-          <div
-            data-test="operation-grid-5-6"
-            class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
-          >
-            6
-          </div>
-        </div>
-      </div>
-      <div style="display: flex; flex-direction: column;">
-        <div data-test="undefined-0-0" class="makeStyles-defaultCell-98">
-          <span
-            ><span class="katex"
-              ><span class="katex-mathml"
-                ><math xmlns="http://www.w3.org/1998/Math/MathML"
-                  ><semantics
-                    ><mrow
-                      ><mover accent="true"
-                        ><mi>M</mi><mo stretchy="true">‾</mo></mover
-                      ></mrow
-                    ><annotation encoding="application/x-tex"
-                      >\\overline{M}</annotation
-                    ></semantics
-                  ></math
-                ></span
-              ><span class="katex-html" aria-hidden="true"
-                ><span class="base"
-                  ><span
-                    class="strut"
-                    style="height:0.8833300000000001em;vertical-align:0em;"
-                  ></span
-                  ><span class="mord overline"
-                    ><span class="vlist-t"
-                      ><span class="vlist-r"
-                        ><span
-                          class="vlist"
-                          style="height:0.8833300000000001em;"
-                          ><span style="top:-3em;"
-                            ><span class="pstrut" style="height:3em;"></span
-                            ><span class="mord"
-                              ><span
-                                class="mord mathnormal"
-                                style="margin-right:0.10903em;"
-                                >M</span
-                              ></span
-                            ></span
-                          ><span style="top:-3.80333em;"
-                            ><span class="pstrut" style="height:3em;"></span
-                            ><span
-                              class="overline-line"
-                              style="border-bottom-width:0.04em;"
-                            ></span></span></span></span></span></span></span></span></span
-          ></span>
-        </div>
-        <div data-test="undefined-0-1" class="makeStyles-defaultCell-98">
-          <span
-            ><span class="katex"
-              ><span class="katex-mathml"
-                ><math xmlns="http://www.w3.org/1998/Math/MathML"
-                  ><semantics
-                    ><mrow><mi>M</mi></mrow
-                    ><annotation encoding="application/x-tex"
-                      >M</annotation
-                    ></semantics
-                  ></math
-                ></span
-              ><span class="katex-html" aria-hidden="true"
-                ><span class="base"
-                  ><span
-                    class="strut"
-                    style="height:0.68333em;vertical-align:0em;"
-                  ></span
-                  ><span class="mord mathnormal" style="margin-right:0.10903em;"
-                    >M</span
-                  ></span
-                ></span
-              ></span
-            ></span
-          >
-        </div>
-        <div data-test="undefined-0-2" class="makeStyles-defaultCell-98">
-          <span
-            ><span class="katex"
-              ><span class="katex-mathml"
-                ><math xmlns="http://www.w3.org/1998/Math/MathML"
-                  ><semantics
-                    ><mrow></mrow
-                    ><annotation encoding="application/x-tex">
-                    </annotation></semantics></math></span
-              ><span class="katex-html" aria-hidden="true"></span></span
-          ></span>
-        </div>
-        <div data-test="undefined-0-3" class="makeStyles-defaultCell-98">
-          <span
-            ><span class="katex"
-              ><span class="katex-mathml"
-                ><math xmlns="http://www.w3.org/1998/Math/MathML"
-                  ><semantics
-                    ><mrow></mrow
-                    ><annotation encoding="application/x-tex">
-                    </annotation></semantics></math></span
-              ><span class="katex-html" aria-hidden="true"></span></span
-          ></span>
-        </div>
-        <div data-test="undefined-0-4" class="makeStyles-defaultCell-98">
-          <span
-            ><span class="katex"
-              ><span class="katex-mathml"
-                ><math xmlns="http://www.w3.org/1998/Math/MathML"
-                  ><semantics
-                    ><mrow></mrow
-                    ><annotation encoding="application/x-tex">
-                    </annotation></semantics></math></span
-              ><span class="katex-html" aria-hidden="true"></span></span
-          ></span>
-        </div>
-        <div data-test="undefined-0-5" class="makeStyles-defaultCell-98">
-          <span
-            ><span class="katex"
-              ><span class="katex-mathml"
-                ><math xmlns="http://www.w3.org/1998/Math/MathML"
-                  ><semantics
-                    ><mrow
-                      ><mover accent="true"
-                        ><mi>M</mi><mo stretchy="true">‾</mo></mover
-                      ></mrow
-                    ><annotation encoding="application/x-tex"
-                      >\\overline{M}</annotation
-                    ></semantics
-                  ></math
-                ></span
-              ><span class="katex-html" aria-hidden="true"
-                ><span class="base"
-                  ><span
-                    class="strut"
-                    style="height:0.8833300000000001em;vertical-align:0em;"
-                  ></span
-                  ><span class="mord overline"
-                    ><span class="vlist-t"
-                      ><span class="vlist-r"
-                        ><span
-                          class="vlist"
-                          style="height:0.8833300000000001em;"
-                          ><span style="top:-3em;"
-                            ><span class="pstrut" style="height:3em;"></span
-                            ><span class="mord"
-                              ><span
-                                class="mord mathnormal"
-                                style="margin-right:0.10903em;"
-                                >M</span
-                              ></span
-                            ></span
-                          ><span style="top:-3.80333em;"
-                            ><span class="pstrut" style="height:3em;"></span
-                            ><span
-                              class="overline-line"
-                              style="border-bottom-width:0.04em;"
-                            ></span></span></span></span></span></span></span></span></span
-          ></span>
-        </div>
-        <div data-test="undefined-0-6" class="makeStyles-defaultCell-98">
-          <span
-            ><span class="katex"
-              ><span class="katex-mathml"
-                ><math xmlns="http://www.w3.org/1998/Math/MathML"
-                  ><semantics
-                    ><mrow></mrow
-                    ><annotation encoding="application/x-tex">
-                    </annotation></semantics></math></span
-              ><span class="katex-html" aria-hidden="true"></span></span
-          ></span>
-        </div>
-      </div>
+<div class="makeStyles-cellContent-93" id="operation-grid">
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-1-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-2-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-3-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      (9)
+    </div>
+    <div
+      data-test="operation-grid-4-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      2
+    </div>
+    <div
+      data-test="operation-grid-5-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
+    >
+      2
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-1" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-1" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-2-1" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-3-1" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-4-1" class="makeStyles-defaultCell-98">
+      7
+    </div>
+    <div
+      data-test="operation-grid-5-1"
+      class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
+    >
+      8
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      *
+    </div>
+    <div
+      data-test="operation-grid-1-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-2-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-3-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      (9)
+    </div>
+    <div
+      data-test="operation-grid-4-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      1
+    </div>
+    <div
+      data-test="operation-grid-5-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
+    >
+      2
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-3" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-3" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-3-3" class="makeStyles-defaultCell-98">
+      1
+    </div>
+    <div data-test="operation-grid-4-3" class="makeStyles-defaultCell-98">
+      5
+    </div>
+    <div
+      data-test="operation-grid-5-3"
+      class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
+    >
+      6
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-4" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-4" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-3-4" class="makeStyles-defaultCell-98">
+      7
+    </div>
+    <div data-test="operation-grid-4-4" class="makeStyles-defaultCell-98">
+      8
+    </div>
+    <div
+      data-test="operation-grid-5-4"
+      class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-5"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      +
+    </div>
+    <div
+      data-test="operation-grid-1-5"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      (9)
+    </div>
+    <div
+      data-test="operation-grid-2-5"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      2
+    </div>
+    <div
+      data-test="operation-grid-3-5"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      2
+    </div>
+    <div
+      data-test="operation-grid-4-5"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-5-5"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-6" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-6" class="makeStyles-defaultCell-98">
+      (9)
+    </div>
+    <div data-test="operation-grid-2-6" class="makeStyles-defaultCell-98">
+      3
+    </div>
+    <div data-test="operation-grid-3-6" class="makeStyles-defaultCell-98">
+      1
+    </div>
+    <div data-test="operation-grid-4-6" class="makeStyles-defaultCell-98">
+      3
+    </div>
+    <div
+      data-test="operation-grid-5-6"
+      class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
+    >
+      6
     </div>
   </div>
 </div>
@@ -4999,191 +4348,161 @@ exports[`Multiplication with extension > should multiply two numbers in base 8 #
 `;
 
 exports[`Multiplication with extension > should multiply two numbers in base 8 #1`] = `
-<div class="makeStyles-gridWrapper-91" id="operation-grid">
-  <div>
-    <div class="makeStyles-cellBox-92">
-      <div class="makeStyles-cellContent-93">
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-1-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-2-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-3-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-4-0" class="makeStyles-defaultCell-98">
-            (7)
-          </div>
-          <div data-test="operation-grid-5-0" class="makeStyles-defaultCell-98">
-            4
-          </div>
-          <div data-test="operation-grid-6-0" class="makeStyles-defaultCell-98">
-            5
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            *
-          </div>
-          <div
-            data-test="operation-grid-1-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-2-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-3-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            (0)
-          </div>
-          <div
-            data-test="operation-grid-4-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            7
-          </div>
-          <div
-            data-test="operation-grid-5-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-6-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            3
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-2"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-1-2" class="makeStyles-defaultCell-98">
-            (7)
-          </div>
-          <div data-test="operation-grid-2-2" class="makeStyles-defaultCell-98">
-            7
-          </div>
-          <div data-test="operation-grid-3-2" class="makeStyles-defaultCell-98">
-            7
-          </div>
-          <div data-test="operation-grid-4-2" class="makeStyles-defaultCell-98">
-            6
-          </div>
-          <div data-test="operation-grid-5-2" class="makeStyles-defaultCell-98">
-            5
-          </div>
-          <div data-test="operation-grid-6-2" class="makeStyles-defaultCell-98">
-            7
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-3"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-1-3" class="makeStyles-defaultCell-98">
-            (7)
-          </div>
-          <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-98">
-            7
-          </div>
-          <div data-test="operation-grid-3-3" class="makeStyles-defaultCell-98">
-            7
-          </div>
-          <div data-test="operation-grid-4-3" class="makeStyles-defaultCell-98">
-            1
-          </div>
-          <div data-test="operation-grid-5-3" class="makeStyles-defaultCell-98">
-            2
-          </div>
-          <div
-            data-test="operation-grid-6-3"
-            class="makeStyles-defaultCell-98"
-          ></div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-4"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            +
-          </div>
-          <div
-            data-test="operation-grid-1-4"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            (7)
-          </div>
-          <div
-            data-test="operation-grid-2-4"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            5
-          </div>
-          <div
-            data-test="operation-grid-3-4"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-4-4"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            3
-          </div>
-          <div
-            data-test="operation-grid-5-4"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-6-4"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-5"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-1-5" class="makeStyles-defaultCell-98">
-            (7)
-          </div>
-          <div data-test="operation-grid-2-5" class="makeStyles-defaultCell-98">
-            4
-          </div>
-          <div data-test="operation-grid-3-5" class="makeStyles-defaultCell-98">
-            7
-          </div>
-          <div data-test="operation-grid-4-5" class="makeStyles-defaultCell-98">
-            2
-          </div>
-          <div data-test="operation-grid-5-5" class="makeStyles-defaultCell-98">
-            7
-          </div>
-          <div data-test="operation-grid-6-5" class="makeStyles-defaultCell-98">
-            7
-          </div>
-        </div>
-      </div>
+<div class="makeStyles-cellContent-93" id="operation-grid">
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-2-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-3-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-4-0" class="makeStyles-defaultCell-98">
+      (7)
+    </div>
+    <div data-test="operation-grid-5-0" class="makeStyles-defaultCell-98">
+      4
+    </div>
+    <div data-test="operation-grid-6-0" class="makeStyles-defaultCell-98">
+      5
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      *
+    </div>
+    <div
+      data-test="operation-grid-1-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-2-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-3-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      (0)
+    </div>
+    <div
+      data-test="operation-grid-4-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      7
+    </div>
+    <div
+      data-test="operation-grid-5-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      2
+    </div>
+    <div
+      data-test="operation-grid-6-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      3
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-2" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-2" class="makeStyles-defaultCell-98">
+      (7)
+    </div>
+    <div data-test="operation-grid-2-2" class="makeStyles-defaultCell-98">
+      7
+    </div>
+    <div data-test="operation-grid-3-2" class="makeStyles-defaultCell-98">
+      7
+    </div>
+    <div data-test="operation-grid-4-2" class="makeStyles-defaultCell-98">
+      6
+    </div>
+    <div data-test="operation-grid-5-2" class="makeStyles-defaultCell-98">
+      5
+    </div>
+    <div data-test="operation-grid-6-2" class="makeStyles-defaultCell-98">
+      7
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-3" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-3" class="makeStyles-defaultCell-98">
+      (7)
+    </div>
+    <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-98">
+      7
+    </div>
+    <div data-test="operation-grid-3-3" class="makeStyles-defaultCell-98">
+      7
+    </div>
+    <div data-test="operation-grid-4-3" class="makeStyles-defaultCell-98">
+      1
+    </div>
+    <div data-test="operation-grid-5-3" class="makeStyles-defaultCell-98">
+      2
+    </div>
+    <div data-test="operation-grid-6-3" class="makeStyles-defaultCell-98"></div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-4"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      +
+    </div>
+    <div
+      data-test="operation-grid-1-4"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      (7)
+    </div>
+    <div
+      data-test="operation-grid-2-4"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      5
+    </div>
+    <div
+      data-test="operation-grid-3-4"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-4-4"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      3
+    </div>
+    <div
+      data-test="operation-grid-5-4"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-6-4"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-5" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-5" class="makeStyles-defaultCell-98">
+      (7)
+    </div>
+    <div data-test="operation-grid-2-5" class="makeStyles-defaultCell-98">
+      4
+    </div>
+    <div data-test="operation-grid-3-5" class="makeStyles-defaultCell-98">
+      7
+    </div>
+    <div data-test="operation-grid-4-5" class="makeStyles-defaultCell-98">
+      2
+    </div>
+    <div data-test="operation-grid-5-5" class="makeStyles-defaultCell-98">
+      7
+    </div>
+    <div data-test="operation-grid-6-5" class="makeStyles-defaultCell-98">
+      7
     </div>
   </div>
 </div>
@@ -5374,576 +4693,343 @@ exports[`Multiplication with extension > should multiply numbers entered as comp
 `;
 
 exports[`Multiplication with extension > should multiply numbers entered as complements in base 8 #1`] = `
-<div class="makeStyles-gridWrapper-91" id="operation-grid">
-  <div>
-    <div class="makeStyles-cellBox-92">
-      <div class="makeStyles-cellContent-93">
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-0"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-1-0"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-2-0"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-3-0"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-4-0"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-5-0"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            (7)
-          </div>
-          <div
-            data-test="operation-grid-6-0"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            4
-          </div>
-          <div
-            data-test="operation-grid-7-0"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            6
-          </div>
-          <div
-            data-test="operation-grid-8-0"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-9-0"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
-          >
-            2
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-1"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-1-1"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-2-1"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-3-1"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-4-1"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-5-1" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-6-1" class="makeStyles-defaultCell-98">
-            3
-          </div>
-          <div data-test="operation-grid-7-1" class="makeStyles-defaultCell-98">
-            1
-          </div>
-          <div data-test="operation-grid-8-1" class="makeStyles-defaultCell-98">
-            5
-          </div>
-          <div
-            data-test="operation-grid-9-1"
-            class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
-          >
-            6
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            *
-          </div>
-          <div
-            data-test="operation-grid-1-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-2-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-3-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-4-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-5-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            (7)
-          </div>
-          <div
-            data-test="operation-grid-6-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            6
-          </div>
-          <div
-            data-test="operation-grid-7-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            4
-          </div>
-          <div
-            data-test="operation-grid-8-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-9-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
-          >
-            3
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-3"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-1-3" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-98">
-            0
-          </div>
-          <div data-test="operation-grid-3-3" class="makeStyles-defaultCell-98">
-            0
-          </div>
-          <div data-test="operation-grid-4-3" class="makeStyles-defaultCell-98">
-            0
-          </div>
-          <div data-test="operation-grid-5-3" class="makeStyles-defaultCell-98">
-            1
-          </div>
-          <div data-test="operation-grid-6-3" class="makeStyles-defaultCell-98">
-            1
-          </div>
-          <div data-test="operation-grid-7-3" class="makeStyles-defaultCell-98">
-            5
-          </div>
-          <div data-test="operation-grid-8-3" class="makeStyles-defaultCell-98">
-            1
-          </div>
-          <div
-            data-test="operation-grid-9-3"
-            class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
-          >
-            2
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-4"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-1-4" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-98">
-            0
-          </div>
-          <div data-test="operation-grid-3-4" class="makeStyles-defaultCell-98">
-            0
-          </div>
-          <div data-test="operation-grid-4-4" class="makeStyles-defaultCell-98">
-            0
-          </div>
-          <div data-test="operation-grid-5-4" class="makeStyles-defaultCell-98">
-            6
-          </div>
-          <div data-test="operation-grid-6-4" class="makeStyles-defaultCell-98">
-            3
-          </div>
-          <div data-test="operation-grid-7-4" class="makeStyles-defaultCell-98">
-            3
-          </div>
-          <div data-test="operation-grid-8-4" class="makeStyles-defaultCell-98">
-            4
-          </div>
-          <div
-            data-test="operation-grid-9-4"
-            class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
-          ></div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-5"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-1-5" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-2-5" class="makeStyles-defaultCell-98">
-            0
-          </div>
-          <div data-test="operation-grid-3-5" class="makeStyles-defaultCell-98">
-            1
-          </div>
-          <div data-test="operation-grid-4-5" class="makeStyles-defaultCell-98">
-            4
-          </div>
-          <div data-test="operation-grid-5-5" class="makeStyles-defaultCell-98">
-            6
-          </div>
-          <div data-test="operation-grid-6-5" class="makeStyles-defaultCell-98">
-            7
-          </div>
-          <div data-test="operation-grid-7-5" class="makeStyles-defaultCell-98">
-            0
-          </div>
-          <div
-            data-test="operation-grid-8-5"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-9-5"
-            class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
-          ></div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-6"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-1-6" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-2-6" class="makeStyles-defaultCell-98">
-            2
-          </div>
-          <div data-test="operation-grid-3-6" class="makeStyles-defaultCell-98">
-            3
-          </div>
-          <div data-test="operation-grid-4-6" class="makeStyles-defaultCell-98">
-            2
-          </div>
-          <div data-test="operation-grid-5-6" class="makeStyles-defaultCell-98">
-            2
-          </div>
-          <div data-test="operation-grid-6-6" class="makeStyles-defaultCell-98">
-            4
-          </div>
-          <div
-            data-test="operation-grid-7-6"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-8-6"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-9-6"
-            class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
-          ></div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-7"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            +
-          </div>
-          <div
-            data-test="operation-grid-1-7"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            (7)
-          </div>
-          <div
-            data-test="operation-grid-2-7"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            4
-          </div>
-          <div
-            data-test="operation-grid-3-7"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            6
-          </div>
-          <div
-            data-test="operation-grid-4-7"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-5-7"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-6-7"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-7-7"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-8-7"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-9-7"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
-          ></div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-8"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-1-8" class="makeStyles-defaultCell-98">
-            (7)
-          </div>
-          <div data-test="operation-grid-2-8" class="makeStyles-defaultCell-98">
-            7
-          </div>
-          <div data-test="operation-grid-3-8" class="makeStyles-defaultCell-98">
-            3
-          </div>
-          <div data-test="operation-grid-4-8" class="makeStyles-defaultCell-98">
-            2
-          </div>
-          <div data-test="operation-grid-5-8" class="makeStyles-defaultCell-98">
-            3
-          </div>
-          <div data-test="operation-grid-6-8" class="makeStyles-defaultCell-98">
-            0
-          </div>
-          <div data-test="operation-grid-7-8" class="makeStyles-defaultCell-98">
-            0
-          </div>
-          <div data-test="operation-grid-8-8" class="makeStyles-defaultCell-98">
-            5
-          </div>
-          <div
-            data-test="operation-grid-9-8"
-            class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
-          >
-            2
-          </div>
-        </div>
-      </div>
-      <div style="display: flex; flex-direction: column;">
-        <div data-test="undefined-0-0" class="makeStyles-defaultCell-98">
-          <span
-            ><span class="katex"
-              ><span class="katex-mathml"
-                ><math xmlns="http://www.w3.org/1998/Math/MathML"
-                  ><semantics
-                    ><mrow
-                      ><mover accent="true"
-                        ><mi>M</mi><mo stretchy="true">‾</mo></mover
-                      ></mrow
-                    ><annotation encoding="application/x-tex"
-                      >\\overline{M}</annotation
-                    ></semantics
-                  ></math
-                ></span
-              ><span class="katex-html" aria-hidden="true"
-                ><span class="base"
-                  ><span
-                    class="strut"
-                    style="height:0.8833300000000001em;vertical-align:0em;"
-                  ></span
-                  ><span class="mord overline"
-                    ><span class="vlist-t"
-                      ><span class="vlist-r"
-                        ><span
-                          class="vlist"
-                          style="height:0.8833300000000001em;"
-                          ><span style="top:-3em;"
-                            ><span class="pstrut" style="height:3em;"></span
-                            ><span class="mord"
-                              ><span
-                                class="mord mathnormal"
-                                style="margin-right:0.10903em;"
-                                >M</span
-                              ></span
-                            ></span
-                          ><span style="top:-3.80333em;"
-                            ><span class="pstrut" style="height:3em;"></span
-                            ><span
-                              class="overline-line"
-                              style="border-bottom-width:0.04em;"
-                            ></span></span></span></span></span></span></span></span></span
-          ></span>
-        </div>
-        <div data-test="undefined-0-1" class="makeStyles-defaultCell-98">
-          <span
-            ><span class="katex"
-              ><span class="katex-mathml"
-                ><math xmlns="http://www.w3.org/1998/Math/MathML"
-                  ><semantics
-                    ><mrow><mi>M</mi></mrow
-                    ><annotation encoding="application/x-tex"
-                      >M</annotation
-                    ></semantics
-                  ></math
-                ></span
-              ><span class="katex-html" aria-hidden="true"
-                ><span class="base"
-                  ><span
-                    class="strut"
-                    style="height:0.68333em;vertical-align:0em;"
-                  ></span
-                  ><span class="mord mathnormal" style="margin-right:0.10903em;"
-                    >M</span
-                  ></span
-                ></span
-              ></span
-            ></span
-          >
-        </div>
-        <div data-test="undefined-0-2" class="makeStyles-defaultCell-98">
-          <span
-            ><span class="katex"
-              ><span class="katex-mathml"
-                ><math xmlns="http://www.w3.org/1998/Math/MathML"
-                  ><semantics
-                    ><mrow></mrow
-                    ><annotation encoding="application/x-tex">
-                    </annotation></semantics></math></span
-              ><span class="katex-html" aria-hidden="true"></span></span
-          ></span>
-        </div>
-        <div data-test="undefined-0-3" class="makeStyles-defaultCell-98">
-          <span
-            ><span class="katex"
-              ><span class="katex-mathml"
-                ><math xmlns="http://www.w3.org/1998/Math/MathML"
-                  ><semantics
-                    ><mrow></mrow
-                    ><annotation encoding="application/x-tex">
-                    </annotation></semantics></math></span
-              ><span class="katex-html" aria-hidden="true"></span></span
-          ></span>
-        </div>
-        <div data-test="undefined-0-4" class="makeStyles-defaultCell-98">
-          <span
-            ><span class="katex"
-              ><span class="katex-mathml"
-                ><math xmlns="http://www.w3.org/1998/Math/MathML"
-                  ><semantics
-                    ><mrow></mrow
-                    ><annotation encoding="application/x-tex">
-                    </annotation></semantics></math></span
-              ><span class="katex-html" aria-hidden="true"></span></span
-          ></span>
-        </div>
-        <div data-test="undefined-0-5" class="makeStyles-defaultCell-98">
-          <span
-            ><span class="katex"
-              ><span class="katex-mathml"
-                ><math xmlns="http://www.w3.org/1998/Math/MathML"
-                  ><semantics
-                    ><mrow></mrow
-                    ><annotation encoding="application/x-tex">
-                    </annotation></semantics></math></span
-              ><span class="katex-html" aria-hidden="true"></span></span
-          ></span>
-        </div>
-        <div data-test="undefined-0-6" class="makeStyles-defaultCell-98">
-          <span
-            ><span class="katex"
-              ><span class="katex-mathml"
-                ><math xmlns="http://www.w3.org/1998/Math/MathML"
-                  ><semantics
-                    ><mrow></mrow
-                    ><annotation encoding="application/x-tex">
-                    </annotation></semantics></math></span
-              ><span class="katex-html" aria-hidden="true"></span></span
-          ></span>
-        </div>
-        <div data-test="undefined-0-7" class="makeStyles-defaultCell-98">
-          <span
-            ><span class="katex"
-              ><span class="katex-mathml"
-                ><math xmlns="http://www.w3.org/1998/Math/MathML"
-                  ><semantics
-                    ><mrow
-                      ><mover accent="true"
-                        ><mi>M</mi><mo stretchy="true">‾</mo></mover
-                      ></mrow
-                    ><annotation encoding="application/x-tex"
-                      >\\overline{M}</annotation
-                    ></semantics
-                  ></math
-                ></span
-              ><span class="katex-html" aria-hidden="true"
-                ><span class="base"
-                  ><span
-                    class="strut"
-                    style="height:0.8833300000000001em;vertical-align:0em;"
-                  ></span
-                  ><span class="mord overline"
-                    ><span class="vlist-t"
-                      ><span class="vlist-r"
-                        ><span
-                          class="vlist"
-                          style="height:0.8833300000000001em;"
-                          ><span style="top:-3em;"
-                            ><span class="pstrut" style="height:3em;"></span
-                            ><span class="mord"
-                              ><span
-                                class="mord mathnormal"
-                                style="margin-right:0.10903em;"
-                                >M</span
-                              ></span
-                            ></span
-                          ><span style="top:-3.80333em;"
-                            ><span class="pstrut" style="height:3em;"></span
-                            ><span
-                              class="overline-line"
-                              style="border-bottom-width:0.04em;"
-                            ></span></span></span></span></span></span></span></span></span
-          ></span>
-        </div>
-        <div data-test="undefined-0-8" class="makeStyles-defaultCell-98">
-          <span
-            ><span class="katex"
-              ><span class="katex-mathml"
-                ><math xmlns="http://www.w3.org/1998/Math/MathML"
-                  ><semantics
-                    ><mrow></mrow
-                    ><annotation encoding="application/x-tex">
-                    </annotation></semantics></math></span
-              ><span class="katex-html" aria-hidden="true"></span></span
-          ></span>
-        </div>
-      </div>
+<div class="makeStyles-cellContent-93" id="operation-grid">
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-1-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-2-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-3-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-4-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-5-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      (7)
+    </div>
+    <div
+      data-test="operation-grid-6-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      4
+    </div>
+    <div
+      data-test="operation-grid-7-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      6
+    </div>
+    <div
+      data-test="operation-grid-8-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      2
+    </div>
+    <div
+      data-test="operation-grid-9-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
+    >
+      2
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-1" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-1" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-2-1" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-3-1" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-4-1" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-5-1" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-6-1" class="makeStyles-defaultCell-98">
+      3
+    </div>
+    <div data-test="operation-grid-7-1" class="makeStyles-defaultCell-98">
+      1
+    </div>
+    <div data-test="operation-grid-8-1" class="makeStyles-defaultCell-98">
+      5
+    </div>
+    <div
+      data-test="operation-grid-9-1"
+      class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
+    >
+      6
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      *
+    </div>
+    <div
+      data-test="operation-grid-1-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-2-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-3-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-4-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-5-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      (7)
+    </div>
+    <div
+      data-test="operation-grid-6-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      6
+    </div>
+    <div
+      data-test="operation-grid-7-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      4
+    </div>
+    <div
+      data-test="operation-grid-8-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      2
+    </div>
+    <div
+      data-test="operation-grid-9-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
+    >
+      3
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-3" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-3" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-98">
+      0
+    </div>
+    <div data-test="operation-grid-3-3" class="makeStyles-defaultCell-98">
+      0
+    </div>
+    <div data-test="operation-grid-4-3" class="makeStyles-defaultCell-98">
+      0
+    </div>
+    <div data-test="operation-grid-5-3" class="makeStyles-defaultCell-98">
+      1
+    </div>
+    <div data-test="operation-grid-6-3" class="makeStyles-defaultCell-98">
+      1
+    </div>
+    <div data-test="operation-grid-7-3" class="makeStyles-defaultCell-98">
+      5
+    </div>
+    <div data-test="operation-grid-8-3" class="makeStyles-defaultCell-98">
+      1
+    </div>
+    <div
+      data-test="operation-grid-9-3"
+      class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
+    >
+      2
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-4" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-4" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-98">
+      0
+    </div>
+    <div data-test="operation-grid-3-4" class="makeStyles-defaultCell-98">
+      0
+    </div>
+    <div data-test="operation-grid-4-4" class="makeStyles-defaultCell-98">
+      0
+    </div>
+    <div data-test="operation-grid-5-4" class="makeStyles-defaultCell-98">
+      6
+    </div>
+    <div data-test="operation-grid-6-4" class="makeStyles-defaultCell-98">
+      3
+    </div>
+    <div data-test="operation-grid-7-4" class="makeStyles-defaultCell-98">
+      3
+    </div>
+    <div data-test="operation-grid-8-4" class="makeStyles-defaultCell-98">
+      4
+    </div>
+    <div
+      data-test="operation-grid-9-4"
+      class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-5" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-5" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-2-5" class="makeStyles-defaultCell-98">
+      0
+    </div>
+    <div data-test="operation-grid-3-5" class="makeStyles-defaultCell-98">
+      1
+    </div>
+    <div data-test="operation-grid-4-5" class="makeStyles-defaultCell-98">
+      4
+    </div>
+    <div data-test="operation-grid-5-5" class="makeStyles-defaultCell-98">
+      6
+    </div>
+    <div data-test="operation-grid-6-5" class="makeStyles-defaultCell-98">
+      7
+    </div>
+    <div data-test="operation-grid-7-5" class="makeStyles-defaultCell-98">
+      0
+    </div>
+    <div data-test="operation-grid-8-5" class="makeStyles-defaultCell-98"></div>
+    <div
+      data-test="operation-grid-9-5"
+      class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-6" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-6" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-2-6" class="makeStyles-defaultCell-98">
+      2
+    </div>
+    <div data-test="operation-grid-3-6" class="makeStyles-defaultCell-98">
+      3
+    </div>
+    <div data-test="operation-grid-4-6" class="makeStyles-defaultCell-98">
+      2
+    </div>
+    <div data-test="operation-grid-5-6" class="makeStyles-defaultCell-98">
+      2
+    </div>
+    <div data-test="operation-grid-6-6" class="makeStyles-defaultCell-98">
+      4
+    </div>
+    <div data-test="operation-grid-7-6" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-8-6" class="makeStyles-defaultCell-98"></div>
+    <div
+      data-test="operation-grid-9-6"
+      class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-7"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      +
+    </div>
+    <div
+      data-test="operation-grid-1-7"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      (7)
+    </div>
+    <div
+      data-test="operation-grid-2-7"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      4
+    </div>
+    <div
+      data-test="operation-grid-3-7"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      6
+    </div>
+    <div
+      data-test="operation-grid-4-7"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      2
+    </div>
+    <div
+      data-test="operation-grid-5-7"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      2
+    </div>
+    <div
+      data-test="operation-grid-6-7"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-7-7"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-8-7"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-9-7"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-8" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-8" class="makeStyles-defaultCell-98">
+      (7)
+    </div>
+    <div data-test="operation-grid-2-8" class="makeStyles-defaultCell-98">
+      7
+    </div>
+    <div data-test="operation-grid-3-8" class="makeStyles-defaultCell-98">
+      3
+    </div>
+    <div data-test="operation-grid-4-8" class="makeStyles-defaultCell-98">
+      2
+    </div>
+    <div data-test="operation-grid-5-8" class="makeStyles-defaultCell-98">
+      3
+    </div>
+    <div data-test="operation-grid-6-8" class="makeStyles-defaultCell-98">
+      0
+    </div>
+    <div data-test="operation-grid-7-8" class="makeStyles-defaultCell-98">
+      0
+    </div>
+    <div data-test="operation-grid-8-8" class="makeStyles-defaultCell-98">
+      5
+    </div>
+    <div
+      data-test="operation-grid-9-8"
+      class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
+    >
+      2
     </div>
   </div>
 </div>
@@ -6386,154 +5472,98 @@ exports[`Subtraction > should subtract two decimal numbers #0`] = `
 `;
 
 exports[`Subtraction > should subtract two decimal numbers #1`] = `
-<div class="makeStyles-gridWrapper-92" id="operation-grid">
-  <div class="makeStyles-indicesBox-95">
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>4</sub></span>
+<div class="makeStyles-cellContent-94" id="operation-grid">
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-0" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-0" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-2-0" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-3-0" class="makeStyles-defaultCell-99">
+      11
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>3</sub></span>
+    <div data-test="operation-grid-4-0" class="makeStyles-defaultCell-99"></div>
+  </div>
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-1" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-1" class="makeStyles-defaultCell-99"></div>
+    <div
+      data-test="operation-grid-2-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      2
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>2</sub></span>
+    <div
+      data-test="operation-grid-3-1"
+      class="makeStyles-crossedOutCell-100 makeStyles-horizontalLine-105"
+    >
+      1
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>1</sub></span>
-    </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>0</sub></span>
+    <div
+      data-test="operation-grid-4-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      11
     </div>
   </div>
-  <div>
-    <div class="makeStyles-cellBox-93">
-      <div class="makeStyles-cellContent-94">
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-1-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-2-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div data-test="operation-grid-3-0" class="makeStyles-defaultCell-99">
-            11
-          </div>
-          <div
-            data-test="operation-grid-4-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-1"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-1-1"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-2-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-3-1"
-            class="makeStyles-crossedOutCell-100 makeStyles-horizontalLine-105"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-4-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            11
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-2"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div data-test="operation-grid-1-2" class="makeStyles-defaultCell-99">
-            (0)
-          </div>
-          <div
-            data-test="operation-grid-2-2"
-            class="makeStyles-crossedOutCell-100"
-          >
-            3
-          </div>
-          <div
-            data-test="operation-grid-3-2"
-            class="makeStyles-crossedOutCell-100"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-4-2"
-            class="makeStyles-crossedOutCell-100"
-          >
-            1
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-3"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            -
-          </div>
-          <div
-            data-test="operation-grid-1-3"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            (0)
-          </div>
-          <div
-            data-test="operation-grid-2-3"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-3-3"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-4-3"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            3
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-4"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div data-test="operation-grid-1-4" class="makeStyles-defaultCell-99">
-            (0)
-          </div>
-          <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-99">
-            1
-          </div>
-          <div data-test="operation-grid-3-4" class="makeStyles-defaultCell-99">
-            9
-          </div>
-          <div data-test="operation-grid-4-4" class="makeStyles-defaultCell-99">
-            8
-          </div>
-        </div>
-      </div>
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-2" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-2" class="makeStyles-defaultCell-99">
+      (0)
+    </div>
+    <div data-test="operation-grid-2-2" class="makeStyles-crossedOutCell-100">
+      3
+    </div>
+    <div data-test="operation-grid-3-2" class="makeStyles-crossedOutCell-100">
+      2
+    </div>
+    <div data-test="operation-grid-4-2" class="makeStyles-crossedOutCell-100">
+      1
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-91">
+    <div
+      data-test="operation-grid-0-3"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      -
+    </div>
+    <div
+      data-test="operation-grid-1-3"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      (0)
+    </div>
+    <div
+      data-test="operation-grid-2-3"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      1
+    </div>
+    <div
+      data-test="operation-grid-3-3"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      2
+    </div>
+    <div
+      data-test="operation-grid-4-3"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      3
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-4" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-4" class="makeStyles-defaultCell-99">
+      (0)
+    </div>
+    <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-3-4" class="makeStyles-defaultCell-99">
+      9
+    </div>
+    <div data-test="operation-grid-4-4" class="makeStyles-defaultCell-99">
+      8
     </div>
   </div>
 </div>
@@ -7006,348 +6036,241 @@ exports[`Subtraction > should subtract two decimal numbers with fraction part #0
 `;
 
 exports[`Subtraction > should subtract two decimal numbers with fraction part #1`] = `
-<div class="makeStyles-gridWrapper-92" id="operation-grid">
-  <div class="makeStyles-indicesBox-95">
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>6</sub></span>
+<div class="makeStyles-cellContent-94" id="operation-grid">
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-0" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-0" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-2-0" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-3-0" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-4-0" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-5-0" class="makeStyles-defaultCell-99">
+      11
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>5</sub></span>
+    <div
+      data-test="operation-grid-6-0"
+      class="makeStyles-defaultCell-99 makeStyles-verticalLine-106"
+    >
+      12
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>4</sub></span>
+    <div data-test="operation-grid-7-0" class="makeStyles-defaultCell-99">
+      10
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>3</sub></span>
+    <div data-test="operation-grid-8-0" class="makeStyles-defaultCell-99">
+      11
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>2</sub></span>
+    <div data-test="operation-grid-9-0" class="makeStyles-defaultCell-99">
+      12
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>1</sub></span>
+    <div data-test="operation-grid-10-0" class="makeStyles-defaultCell-99">
+      9
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>0</sub></span>
+    <div
+      data-test="operation-grid-11-0"
+      class="makeStyles-defaultCell-99"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-1" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-1" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-2-1" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-3-1" class="makeStyles-defaultCell-99"></div>
+    <div
+      data-test="operation-grid-4-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      6
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>-1</sub></span>
+    <div
+      data-test="operation-grid-5-1"
+      class="makeStyles-crossedOutCell-100 makeStyles-horizontalLine-105"
+    >
+      1
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>-2</sub></span>
+    <div
+      data-test="operation-grid-6-1"
+      class="makeStyles-crossedOutCell-100 makeStyles-horizontalLine-105 makeStyles-verticalLine-106"
+    >
+      2
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>-3</sub></span>
+    <div
+      data-test="operation-grid-7-1"
+      class="makeStyles-crossedOutCell-100 makeStyles-horizontalLine-105"
+    >
+      0
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>-4</sub></span>
+    <div
+      data-test="operation-grid-8-1"
+      class="makeStyles-crossedOutCell-100 makeStyles-horizontalLine-105"
+    >
+      1
     </div>
-    <div class="makeStyles-columnIndex-96">
-      <span>n<sub>-5</sub></span>
+    <div
+      data-test="operation-grid-9-1"
+      class="makeStyles-crossedOutCell-100 makeStyles-horizontalLine-105"
+    >
+      2
+    </div>
+    <div
+      data-test="operation-grid-10-1"
+      class="makeStyles-crossedOutCell-100 makeStyles-horizontalLine-105"
+    >
+      -1
+    </div>
+    <div
+      data-test="operation-grid-11-1"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      10
     </div>
   </div>
-  <div>
-    <div class="makeStyles-cellBox-93">
-      <div class="makeStyles-cellContent-94">
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-1-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-2-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-3-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-4-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div data-test="operation-grid-5-0" class="makeStyles-defaultCell-99">
-            11
-          </div>
-          <div
-            data-test="operation-grid-6-0"
-            class="makeStyles-defaultCell-99 makeStyles-verticalLine-106"
-          >
-            12
-          </div>
-          <div data-test="operation-grid-7-0" class="makeStyles-defaultCell-99">
-            10
-          </div>
-          <div data-test="operation-grid-8-0" class="makeStyles-defaultCell-99">
-            11
-          </div>
-          <div data-test="operation-grid-9-0" class="makeStyles-defaultCell-99">
-            12
-          </div>
-          <div
-            data-test="operation-grid-10-0"
-            class="makeStyles-defaultCell-99"
-          >
-            9
-          </div>
-          <div
-            data-test="operation-grid-11-0"
-            class="makeStyles-defaultCell-99"
-          ></div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-1"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-1-1"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-2-1"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-3-1"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div
-            data-test="operation-grid-4-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            6
-          </div>
-          <div
-            data-test="operation-grid-5-1"
-            class="makeStyles-crossedOutCell-100 makeStyles-horizontalLine-105"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-6-1"
-            class="makeStyles-crossedOutCell-100 makeStyles-horizontalLine-105 makeStyles-verticalLine-106"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-7-1"
-            class="makeStyles-crossedOutCell-100 makeStyles-horizontalLine-105"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-8-1"
-            class="makeStyles-crossedOutCell-100 makeStyles-horizontalLine-105"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-9-1"
-            class="makeStyles-crossedOutCell-100 makeStyles-horizontalLine-105"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-10-1"
-            class="makeStyles-crossedOutCell-100 makeStyles-horizontalLine-105"
-          >
-            -1
-          </div>
-          <div
-            data-test="operation-grid-11-1"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            10
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-2"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div data-test="operation-grid-1-2" class="makeStyles-defaultCell-99">
-            (0)
-          </div>
-          <div data-test="operation-grid-2-2" class="makeStyles-defaultCell-99">
-            9
-          </div>
-          <div data-test="operation-grid-3-2" class="makeStyles-defaultCell-99">
-            8
-          </div>
-          <div
-            data-test="operation-grid-4-2"
-            class="makeStyles-crossedOutCell-100"
-          >
-            7
-          </div>
-          <div
-            data-test="operation-grid-5-2"
-            class="makeStyles-crossedOutCell-100"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-6-2"
-            class="makeStyles-crossedOutCell-100 makeStyles-verticalLine-106"
-          >
-            3
-          </div>
-          <div
-            data-test="operation-grid-7-2"
-            class="makeStyles-crossedOutCell-100"
-          >
-            1
-          </div>
-          <div
-            data-test="operation-grid-8-2"
-            class="makeStyles-crossedOutCell-100"
-          >
-            2
-          </div>
-          <div
-            data-test="operation-grid-9-2"
-            class="makeStyles-crossedOutCell-100"
-          >
-            3
-          </div>
-          <div
-            data-test="operation-grid-10-2"
-            class="makeStyles-crossedOutCell-100"
-          >
-            0
-          </div>
-          <div
-            data-test="operation-grid-11-2"
-            class="makeStyles-crossedOutCell-100"
-          >
-            0
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-3"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            -
-          </div>
-          <div
-            data-test="operation-grid-1-3"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          ></div>
-          <div
-            data-test="operation-grid-2-3"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            (0)
-          </div>
-          <div
-            data-test="operation-grid-3-3"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            7
-          </div>
-          <div
-            data-test="operation-grid-4-3"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            6
-          </div>
-          <div
-            data-test="operation-grid-5-3"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            4
-          </div>
-          <div
-            data-test="operation-grid-6-3"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105 makeStyles-verticalLine-106"
-          >
-            3
-          </div>
-          <div
-            data-test="operation-grid-7-3"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            8
-          </div>
-          <div
-            data-test="operation-grid-8-3"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            7
-          </div>
-          <div
-            data-test="operation-grid-9-3"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            5
-          </div>
-          <div
-            data-test="operation-grid-10-3"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            4
-          </div>
-          <div
-            data-test="operation-grid-11-3"
-            class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
-          >
-            3
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-91">
-          <div
-            data-test="operation-grid-0-4"
-            class="makeStyles-defaultCell-99"
-          ></div>
-          <div data-test="operation-grid-1-4" class="makeStyles-defaultCell-99">
-            (0)
-          </div>
-          <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-99">
-            9
-          </div>
-          <div data-test="operation-grid-3-4" class="makeStyles-defaultCell-99">
-            1
-          </div>
-          <div data-test="operation-grid-4-4" class="makeStyles-defaultCell-99">
-            0
-          </div>
-          <div data-test="operation-grid-5-4" class="makeStyles-defaultCell-99">
-            7
-          </div>
-          <div
-            data-test="operation-grid-6-4"
-            class="makeStyles-defaultCell-99 makeStyles-verticalLine-106"
-          >
-            9
-          </div>
-          <div data-test="operation-grid-7-4" class="makeStyles-defaultCell-99">
-            2
-          </div>
-          <div data-test="operation-grid-8-4" class="makeStyles-defaultCell-99">
-            4
-          </div>
-          <div data-test="operation-grid-9-4" class="makeStyles-defaultCell-99">
-            7
-          </div>
-          <div
-            data-test="operation-grid-10-4"
-            class="makeStyles-defaultCell-99"
-          >
-            5
-          </div>
-          <div
-            data-test="operation-grid-11-4"
-            class="makeStyles-defaultCell-99"
-          >
-            7
-          </div>
-        </div>
-      </div>
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-2" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-2" class="makeStyles-defaultCell-99">
+      (0)
+    </div>
+    <div data-test="operation-grid-2-2" class="makeStyles-defaultCell-99">
+      9
+    </div>
+    <div data-test="operation-grid-3-2" class="makeStyles-defaultCell-99">
+      8
+    </div>
+    <div data-test="operation-grid-4-2" class="makeStyles-crossedOutCell-100">
+      7
+    </div>
+    <div data-test="operation-grid-5-2" class="makeStyles-crossedOutCell-100">
+      2
+    </div>
+    <div
+      data-test="operation-grid-6-2"
+      class="makeStyles-crossedOutCell-100 makeStyles-verticalLine-106"
+    >
+      3
+    </div>
+    <div data-test="operation-grid-7-2" class="makeStyles-crossedOutCell-100">
+      1
+    </div>
+    <div data-test="operation-grid-8-2" class="makeStyles-crossedOutCell-100">
+      2
+    </div>
+    <div data-test="operation-grid-9-2" class="makeStyles-crossedOutCell-100">
+      3
+    </div>
+    <div data-test="operation-grid-10-2" class="makeStyles-crossedOutCell-100">
+      0
+    </div>
+    <div data-test="operation-grid-11-2" class="makeStyles-crossedOutCell-100">
+      0
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-91">
+    <div
+      data-test="operation-grid-0-3"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      -
+    </div>
+    <div
+      data-test="operation-grid-1-3"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    ></div>
+    <div
+      data-test="operation-grid-2-3"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      (0)
+    </div>
+    <div
+      data-test="operation-grid-3-3"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      7
+    </div>
+    <div
+      data-test="operation-grid-4-3"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      6
+    </div>
+    <div
+      data-test="operation-grid-5-3"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      4
+    </div>
+    <div
+      data-test="operation-grid-6-3"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105 makeStyles-verticalLine-106"
+    >
+      3
+    </div>
+    <div
+      data-test="operation-grid-7-3"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      8
+    </div>
+    <div
+      data-test="operation-grid-8-3"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      7
+    </div>
+    <div
+      data-test="operation-grid-9-3"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      5
+    </div>
+    <div
+      data-test="operation-grid-10-3"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      4
+    </div>
+    <div
+      data-test="operation-grid-11-3"
+      class="makeStyles-defaultCell-99 makeStyles-horizontalLine-105"
+    >
+      3
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-91">
+    <div data-test="operation-grid-0-4" class="makeStyles-defaultCell-99"></div>
+    <div data-test="operation-grid-1-4" class="makeStyles-defaultCell-99">
+      (0)
+    </div>
+    <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-99">
+      9
+    </div>
+    <div data-test="operation-grid-3-4" class="makeStyles-defaultCell-99">
+      1
+    </div>
+    <div data-test="operation-grid-4-4" class="makeStyles-defaultCell-99">
+      0
+    </div>
+    <div data-test="operation-grid-5-4" class="makeStyles-defaultCell-99">
+      7
+    </div>
+    <div
+      data-test="operation-grid-6-4"
+      class="makeStyles-defaultCell-99 makeStyles-verticalLine-106"
+    >
+      9
+    </div>
+    <div data-test="operation-grid-7-4" class="makeStyles-defaultCell-99">
+      2
+    </div>
+    <div data-test="operation-grid-8-4" class="makeStyles-defaultCell-99">
+      4
+    </div>
+    <div data-test="operation-grid-9-4" class="makeStyles-defaultCell-99">
+      7
+    </div>
+    <div data-test="operation-grid-10-4" class="makeStyles-defaultCell-99">
+      5
+    </div>
+    <div data-test="operation-grid-11-4" class="makeStyles-defaultCell-99">
+      7
     </div>
   </div>
 </div>
@@ -7533,121 +6456,97 @@ exports[`Multiplication with extension > should multiply number by 0 #0`] = `
 `;
 
 exports[`Multiplication with extension > should multiply number by 0 #1`] = `
-<div class="makeStyles-gridWrapper-91" id="operation-grid">
-  <div>
-    <div class="makeStyles-cellBox-92">
-      <div class="makeStyles-cellContent-93">
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-1-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-2-0" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-3-0" class="makeStyles-defaultCell-98">
-            1
-          </div>
-          <div data-test="operation-grid-4-0" class="makeStyles-defaultCell-98">
-            2
-          </div>
-          <div data-test="operation-grid-5-0" class="makeStyles-defaultCell-98">
-            3
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            *
-          </div>
-          <div
-            data-test="operation-grid-1-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-2-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-3-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-4-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            (0)
-          </div>
-          <div
-            data-test="operation-grid-5-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            0
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            +
-          </div>
-          <div
-            data-test="operation-grid-1-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-2-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-3-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-4-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            (0)
-          </div>
-          <div
-            data-test="operation-grid-5-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            0
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-3"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-1-3"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-2-3"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-3-3"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-4-3" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-5-3" class="makeStyles-defaultCell-98">
-            0
-          </div>
-        </div>
-      </div>
+<div class="makeStyles-cellContent-93" id="operation-grid">
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-2-0" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-3-0" class="makeStyles-defaultCell-98">
+      1
+    </div>
+    <div data-test="operation-grid-4-0" class="makeStyles-defaultCell-98">
+      2
+    </div>
+    <div data-test="operation-grid-5-0" class="makeStyles-defaultCell-98">
+      3
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      *
+    </div>
+    <div
+      data-test="operation-grid-1-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-2-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-3-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-4-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      (0)
+    </div>
+    <div
+      data-test="operation-grid-5-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      0
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      +
+    </div>
+    <div
+      data-test="operation-grid-1-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-2-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-3-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-4-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      (0)
+    </div>
+    <div
+      data-test="operation-grid-5-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      0
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-3" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-3" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-3-3" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-4-3" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-5-3" class="makeStyles-defaultCell-98">
+      0
     </div>
   </div>
 </div>
@@ -7832,91 +6731,73 @@ exports[`Multiplication with extension > should multiply 0 by number #0`] = `
 `;
 
 exports[`Multiplication with extension > should multiply 0 by number #1`] = `
-<div class="makeStyles-gridWrapper-91" id="operation-grid">
-  <div>
-    <div class="makeStyles-cellBox-92">
-      <div class="makeStyles-cellContent-93">
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-1-0"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-2-0" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-3-0" class="makeStyles-defaultCell-98">
-            0
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            *
-          </div>
-          <div
-            data-test="operation-grid-1-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-2-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            (0)
-          </div>
-          <div
-            data-test="operation-grid-3-1"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            9
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            +
-          </div>
-          <div
-            data-test="operation-grid-1-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          ></div>
-          <div
-            data-test="operation-grid-2-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            (0)
-          </div>
-          <div
-            data-test="operation-grid-3-2"
-            class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-          >
-            0
-          </div>
-        </div>
-        <div class="makeStyles-gridRow-90">
-          <div
-            data-test="operation-grid-0-3"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div
-            data-test="operation-grid-1-3"
-            class="makeStyles-defaultCell-98"
-          ></div>
-          <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-98">
-            (0)
-          </div>
-          <div data-test="operation-grid-3-3" class="makeStyles-defaultCell-98">
-            0
-          </div>
-        </div>
-      </div>
+<div class="makeStyles-cellContent-93" id="operation-grid">
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-0" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-2-0" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-3-0" class="makeStyles-defaultCell-98">
+      0
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      *
+    </div>
+    <div
+      data-test="operation-grid-1-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-2-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      (0)
+    </div>
+    <div
+      data-test="operation-grid-3-1"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      9
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div
+      data-test="operation-grid-0-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      +
+    </div>
+    <div
+      data-test="operation-grid-1-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-2-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      (0)
+    </div>
+    <div
+      data-test="operation-grid-3-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      0
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-90">
+    <div data-test="operation-grid-0-3" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-1-3" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-98">
+      (0)
+    </div>
+    <div data-test="operation-grid-3-3" class="makeStyles-defaultCell-98">
+      0
     </div>
   </div>
 </div>

--- a/apps/calc-web-e2e/cypress.json
+++ b/apps/calc-web-e2e/cypress.json
@@ -10,6 +10,8 @@
     "videosFolder": "../../dist/cypress/apps/calc-web-e2e/videos",
     "screenshotsFolder": "../../dist/cypress/apps/calc-web-e2e/screenshots",
     "chromeWebSecurity": false,
+    "trashAssetsBeforeRuns": false,
+    "downloadsFolder": "downloads",
     "viewportHeight": 900,
     "viewportWidth": 1300,
     "ignoreTestFiles": [

--- a/apps/calc-web-e2e/src/integration/positional/multiplication.spec.ts
+++ b/apps/calc-web-e2e/src/integration/positional/multiplication.spec.ts
@@ -3,8 +3,10 @@ import { AlgorithmType, MultiplicationType, OperationType } from '@calc/calc-ari
 import {
     getMultiplicationResult,
     getOperationGrid,
+    getOperationGridSaveButton,
     operationReturnsProperResult
 } from '../../support/positional-calculator';
+import { validateImage } from '../../support/image';
 
 describe('Default multiplication', () => {
     beforeEach(() => {
@@ -140,5 +142,20 @@ describe('Multiplication with extension', () => {
 
         getMultiplicationResult().toMatchSnapshot();
         getOperationGrid().toMatchSnapshot();
+    });
+
+    // #111
+    it('should multiply numbers and download result grid as image', () => {
+        const config: OperationTemplate<AlgorithmType> = {
+            operands: ['(0)3156', '(7)6423'],
+            operation: OperationType.Multiplication,
+            algorithm: MultiplicationType.WithExtension,
+            base: 8
+        };
+        const expected = '-4547726';
+
+        operationReturnsProperResult(config, expected);
+        getOperationGridSaveButton().click();
+        validateImage('result.png');
     });
 });

--- a/apps/calc-web-e2e/src/support/image.ts
+++ b/apps/calc-web-e2e/src/support/image.ts
@@ -1,0 +1,12 @@
+import path from 'path';
+
+const downloadsFolder = 'downloads';
+
+export function validateImage(downloadedFilename: string) {
+    const downloadPath = path.join(downloadsFolder, downloadedFilename);
+
+    cy.readFile(downloadPath, 'binary', { timeout: 15000 })
+        .should((buffer) => {
+            expect(buffer.length).to.be.gt(1000);
+        });
+}

--- a/apps/calc-web-e2e/src/support/positional-calculator.ts
+++ b/apps/calc-web-e2e/src/support/positional-calculator.ts
@@ -33,6 +33,7 @@ export const getSubtractionResult = () => cy.getByDataTest('subtraction-result')
 export const getMultiplicationResult = () => cy.getByDataTest('multiplication-result');
 
 export const getOperationGrid = () => cy.get('#operation-grid');
+export const getOperationGridSaveButton = () => cy.getByDataTest('operation-grid-save');
 
 
 export const calculatePositional = (config: OperationTemplate<AlgorithmType>) => {

--- a/libs/common-ui/src/lib/components/save-as-image/save-as-image-button.tsx
+++ b/libs/common-ui/src/lib/components/save-as-image/save-as-image-button.tsx
@@ -11,7 +11,8 @@ interface P {
 
 export const SaveAsImageButton: FC<P> = ({ elementId, tooltipTitle }) => {
     const saveAsImage = async () => {
-        await DomToImage.toBlob(document.getElementById(elementId))
+        const element = document.getElementById(elementId);
+        await DomToImage.toBlob(element)
             .then(blob => {
                 saveAs(blob, 'result.png');
             }).catch((error) => console.log(error));
@@ -20,6 +21,7 @@ export const SaveAsImageButton: FC<P> = ({ elementId, tooltipTitle }) => {
     return (
         <Tooltip title={tooltipTitle}>
             <IconButton
+                data-test={`${elementId}-save`}
                 color={'default'}
                 size={'small'}
                 onClick={saveAsImage}>

--- a/libs/grid/src/lib/components/hover-grid/hover-grid.tsx
+++ b/libs/grid/src/lib/components/hover-grid/hover-grid.tsx
@@ -202,7 +202,7 @@ export const HoverGrid: FC<HoverGridProps> = (
     }) : [];
 
     return (
-        <div className={classes.gridWrapper} id={id}>
+        <div className={classes.gridWrapper}>
             {
                 xAxis &&
                 <div className={classes.indicesBox}>
@@ -211,7 +211,7 @@ export const HoverGrid: FC<HoverGridProps> = (
             }
             <div>
                 <div className={classes.cellBox}>
-                    <div className={classes.cellContent} ref={gridRef}>
+                    <div className={classes.cellContent} ref={gridRef} id={id}>
                         {rows}
                     </div>
                     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1476,9 +1476,9 @@
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "version": "3.2.7",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
                     "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
@@ -3794,9 +3794,9 @@
             }
         },
         "@samverschueren/stream-to-observable": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
-            "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
+            "integrity": "sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==",
             "dev": true,
             "requires": {
                 "any-observable": "^0.3.0"
@@ -4160,34 +4160,6 @@
                 "bignumber.js": "*"
             }
         },
-        "@types/blob-util": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@types/blob-util/-/blob-util-1.3.3.tgz",
-            "integrity": "sha512-4ahcL/QDnpjWA2Qs16ZMQif7HjGP2cw3AGjHabybjw7Vm1EKu+cfQN1D78BaZbS1WJNa1opSMF5HNMztx7lR0w==",
-            "dev": true
-        },
-        "@types/bluebird": {
-            "version": "3.5.29",
-            "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.29.tgz",
-            "integrity": "sha512-kmVtnxTuUuhCET669irqQmPAez4KFnFVKvpleVRyfC3g+SHD1hIkFZcWLim9BVcwUBLO59o8VZE4yGCmTif8Yw==",
-            "dev": true
-        },
-        "@types/chai": {
-            "version": "4.2.7",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.7.tgz",
-            "integrity": "sha512-luq8meHGYwvky0O7u0eQZdA7B4Wd9owUCqvbw2m3XCrCU8mplYOujMBbvyS547AxJkC+pGnd0Cm15eNxEUNU8g==",
-            "dev": true
-        },
-        "@types/chai-jquery": {
-            "version": "1.1.40",
-            "resolved": "https://registry.npmjs.org/@types/chai-jquery/-/chai-jquery-1.1.40.tgz",
-            "integrity": "sha512-mCNEZ3GKP7T7kftKeIs7QmfZZQM7hslGSpYzKbOlR2a2HCFf9ph4nlMRA9UnuOETeOQYJVhJQK7MwGqNZVyUtQ==",
-            "dev": true,
-            "requires": {
-                "@types/chai": "*",
-                "@types/jquery": "*"
-            }
-        },
         "@types/cheerio": {
             "version": "0.22.18",
             "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.18.tgz",
@@ -4308,15 +4280,6 @@
                 "pretty-format": "^25.1.0"
             }
         },
-        "@types/jquery": {
-            "version": "3.3.31",
-            "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.31.tgz",
-            "integrity": "sha512-Lz4BAJihoFw5nRzKvg4nawXPzutkv7wmfQ5121avptaSIXlDNJCUuxZxX/G+9EVidZGuO0UBlk+YjKbwRKJigg==",
-            "dev": true,
-            "requires": {
-                "@types/sizzle": "*"
-            }
-        },
         "@types/json-schema": {
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
@@ -4328,22 +4291,10 @@
             "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
             "dev": true
         },
-        "@types/lodash": {
-            "version": "4.14.149",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-            "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
-            "dev": true
-        },
         "@types/minimatch": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
             "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-            "dev": true
-        },
-        "@types/mocha": {
-            "version": "5.2.7",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
-            "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
             "dev": true
         },
         "@types/node": {
@@ -4455,21 +4406,11 @@
                 "@types/node": "*"
             }
         },
-        "@types/sinon": {
-            "version": "7.5.1",
-            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.1.tgz",
-            "integrity": "sha512-EZQUP3hSZQyTQRfiLqelC9NMWd1kqLcmQE0dMiklxBkgi84T+cHOhnKpgk4NnOWpGX863yE6+IaGnOXUNFqDnQ==",
+        "@types/sinonjs__fake-timers": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
+            "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
             "dev": true
-        },
-        "@types/sinon-chai": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.3.tgz",
-            "integrity": "sha512-TOUFS6vqS0PVL1I8NGVSNcFaNJtFoyZPXZ5zur+qlhDfOmQECZZM4H4kKgca6O8L+QceX/ymODZASfUfn+y4yQ==",
-            "dev": true,
-            "requires": {
-                "@types/chai": "*",
-                "@types/sinon": "*"
-            }
         },
         "@types/sizzle": {
             "version": "2.3.2",
@@ -5567,6 +5508,12 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
         },
+        "at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+            "dev": true
+        },
         "atob": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -6073,6 +6020,12 @@
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
             "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
+        },
+        "blob-util": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
+            "integrity": "sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==",
+            "dev": true
         },
         "bluebird": {
             "version": "3.7.1",
@@ -6755,41 +6708,14 @@
             "dev": true
         },
         "cli-table3": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-            "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
+            "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
             "dev": true,
             "requires": {
                 "colors": "^1.1.2",
                 "object-assign": "^4.1.0",
-                "string-width": "^2.1.1"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^3.0.0"
-                    }
-                }
+                "string-width": "^4.2.0"
             }
         },
         "cli-truncate": {
@@ -7940,67 +7866,56 @@
             "dev": true
         },
         "cypress": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.5.0.tgz",
-            "integrity": "sha512-2A4g5FW5d2fHzq8HKUGAMVTnW6P8nlWYQALiCoGN4bqBLvgwhYM/oG9oKc2CS6LnvgHFiKivKzpm9sfk3uU3zQ==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.3.0.tgz",
+            "integrity": "sha512-Ec6TAFOxdSB2HPINNJ1f7z75pENXcfCaQkz+A9j0eGSvusFJ2NNErq650DexCbNJAnCQkPqXB4XPH9kXnSQnUA==",
             "dev": true,
             "requires": {
-                "@cypress/listr-verbose-renderer": "0.4.1",
-                "@cypress/request": "2.88.5",
-                "@cypress/xvfb": "1.2.4",
-                "@types/blob-util": "1.3.3",
-                "@types/bluebird": "3.5.29",
-                "@types/chai": "4.2.7",
-                "@types/chai-jquery": "1.1.40",
-                "@types/jquery": "3.3.31",
-                "@types/lodash": "4.14.149",
-                "@types/minimatch": "3.0.3",
-                "@types/mocha": "5.2.7",
-                "@types/sinon": "7.5.1",
-                "@types/sinon-chai": "3.2.3",
-                "@types/sizzle": "2.3.2",
-                "arch": "2.1.1",
-                "bluebird": "3.7.2",
-                "cachedir": "2.3.0",
-                "chalk": "2.4.2",
-                "check-more-types": "2.24.0",
-                "cli-table3": "0.5.1",
-                "commander": "4.1.0",
-                "common-tags": "1.8.0",
-                "debug": "4.1.1",
-                "eventemitter2": "4.1.2",
-                "execa": "1.0.0",
-                "executable": "4.1.1",
-                "extract-zip": "1.7.0",
-                "fs-extra": "8.1.0",
-                "getos": "3.1.4",
-                "is-ci": "2.0.0",
-                "is-installed-globally": "0.1.0",
-                "lazy-ass": "1.6.0",
-                "listr": "0.14.3",
-                "lodash": "4.17.15",
-                "log-symbols": "3.0.0",
-                "minimist": "1.2.5",
-                "moment": "2.24.0",
-                "ospath": "1.2.2",
-                "pretty-bytes": "5.3.0",
-                "ramda": "0.26.1",
-                "request-progress": "3.0.0",
-                "supports-color": "7.1.0",
-                "tmp": "0.1.0",
-                "untildify": "4.0.0",
-                "url": "0.11.0",
-                "yauzl": "2.10.0"
+                "@cypress/listr-verbose-renderer": "^0.4.1",
+                "@cypress/request": "^2.88.5",
+                "@cypress/xvfb": "^1.2.4",
+                "@types/sinonjs__fake-timers": "^6.0.1",
+                "@types/sizzle": "^2.3.2",
+                "arch": "^2.1.2",
+                "blob-util": "2.0.2",
+                "bluebird": "^3.7.2",
+                "cachedir": "^2.3.0",
+                "chalk": "^4.1.0",
+                "check-more-types": "^2.24.0",
+                "cli-table3": "~0.6.0",
+                "commander": "^5.1.0",
+                "common-tags": "^1.8.0",
+                "debug": "^4.1.1",
+                "eventemitter2": "^6.4.2",
+                "execa": "^4.0.2",
+                "executable": "^4.1.1",
+                "extract-zip": "^1.7.0",
+                "fs-extra": "^9.0.1",
+                "getos": "^3.2.1",
+                "is-ci": "^2.0.0",
+                "is-installed-globally": "^0.3.2",
+                "lazy-ass": "^1.6.0",
+                "listr": "^0.14.3",
+                "lodash": "^4.17.19",
+                "log-symbols": "^4.0.0",
+                "minimist": "^1.2.5",
+                "moment": "^2.27.0",
+                "ospath": "^1.2.2",
+                "pretty-bytes": "^5.4.1",
+                "ramda": "~0.26.1",
+                "request-progress": "^3.0.0",
+                "supports-color": "^7.2.0",
+                "tmp": "~0.2.1",
+                "untildify": "^4.0.0",
+                "url": "^0.11.0",
+                "yauzl": "^2.10.0"
             },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
+                "arch": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+                    "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+                    "dev": true
                 },
                 "bluebird": {
                     "version": "3.7.2",
@@ -8009,67 +7924,165 @@
                     "dev": true
                 },
                 "chalk": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                            "dev": true,
-                            "requires": {
-                                "has-flag": "^3.0.0"
-                            }
-                        }
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
-                },
-                "color-convert": {
-                    "version": "1.9.3",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "1.1.3"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-                    "dev": true
                 },
                 "commander": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
-                    "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+                    "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
                     "dev": true
                 },
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-                    "dev": true
-                },
-                "lodash": {
-                    "version": "4.17.15",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-                    "dev": true
-                },
-                "tmp": {
-                    "version": "0.1.0",
-                    "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-                    "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+                "cross-spawn": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+                    "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
                     "dev": true,
                     "requires": {
-                        "rimraf": "^2.6.3"
+                        "path-key": "^3.1.0",
+                        "shebang-command": "^2.0.0",
+                        "which": "^2.0.1"
+                    }
+                },
+                "execa": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+                    "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.0",
+                        "get-stream": "^5.0.0",
+                        "human-signals": "^1.1.1",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.0",
+                        "onetime": "^5.1.0",
+                        "signal-exit": "^3.0.2",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "fs-extra": {
+                    "version": "9.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "dev": true,
+                    "requires": {
+                        "at-least-node": "^1.0.0",
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "is-stream": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+                    "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+                    "dev": true
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "log-symbols": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+                    "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "npm-run-path": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+                    "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.0.0"
+                    }
+                },
+                "path-key": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+                    "dev": true
+                },
+                "rimraf": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "shebang-command": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^3.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "tmp": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+                    "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+                    "dev": true,
+                    "requires": {
+                        "rimraf": "^3.0.0"
+                    }
+                },
+                "universalify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+                    "dev": true
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
                     }
                 }
             }
@@ -9466,9 +9479,9 @@
             "dev": true
         },
         "eventemitter2": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-4.1.2.tgz",
-            "integrity": "sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU=",
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.3.tgz",
+            "integrity": "sha512-t0A2msp6BzOf+QAcI6z9XMktLj52OjGQg+8SJH6v5+3uxNpWYRR3wQmfA+6xtMU9kOC59qk9licus5dYcrYkMQ==",
             "dev": true
         },
         "eventemitter3": {
@@ -10435,12 +10448,12 @@
             "dev": true
         },
         "getos": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/getos/-/getos-3.1.4.tgz",
-            "integrity": "sha512-UORPzguEB/7UG5hqiZai8f0vQ7hzynMQyJLxStoQ8dPGAcmgsfXOPA4iE/fGtweHYkK+z4zc9V0g+CIFRf5HYw==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
+            "integrity": "sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==",
             "dev": true,
             "requires": {
-                "async": "^3.1.0"
+                "async": "^3.2.0"
             },
             "dependencies": {
                 "async": {
@@ -10612,12 +10625,20 @@
             }
         },
         "global-dirs": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-            "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
+            "integrity": "sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==",
             "dev": true,
             "requires": {
-                "ini": "^1.3.4"
+                "ini": "1.3.7"
+            },
+            "dependencies": {
+                "ini": {
+                    "version": "1.3.7",
+                    "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+                    "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
+                    "dev": true
+                }
             }
         },
         "globals": {
@@ -11825,23 +11846,20 @@
             "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
         },
         "is-installed-globally": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-            "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
+            "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
             "dev": true,
             "requires": {
-                "global-dirs": "^0.1.0",
-                "is-path-inside": "^1.0.0"
+                "global-dirs": "^2.0.1",
+                "is-path-inside": "^3.0.1"
             },
             "dependencies": {
                 "is-path-inside": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-                    "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-                    "dev": true,
-                    "requires": {
-                        "path-is-inside": "^1.0.1"
-                    }
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+                    "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+                    "dev": true
                 }
             }
         },
@@ -13963,14 +13981,6 @@
                 "listr-verbose-renderer": "^0.5.0",
                 "p-map": "^2.0.0",
                 "rxjs": "^6.3.3"
-            },
-            "dependencies": {
-                "p-map": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-                    "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-                    "dev": true
-                }
             }
         },
         "listr-silent-renderer": {
@@ -15068,9 +15078,9 @@
             }
         },
         "moment": {
-            "version": "2.24.0",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+            "version": "2.29.1",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+            "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
             "dev": true
         },
         "moo": {
@@ -16911,9 +16921,9 @@
             "dev": true
         },
         "pretty-bytes": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
-            "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.5.0.tgz",
+            "integrity": "sha512-p+T744ZyjjiaFlMUZZv6YPC5JrkNj8maRmPaQCWFJFplUAzpIUTRaTcS+7wmZtUoFXHtESJb23ISliaWyz3SHA==",
             "dev": true
         },
         "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "@typescript-eslint/eslint-plugin": "2.19.2",
         "@typescript-eslint/parser": "2.19.2",
         "@wasm-tool/wasm-pack-plugin": "^1.3.1",
-        "cypress": "^4.1.0",
+        "cypress": "^6.3.0",
         "cypress-visual-regression": "^1.5.6",
         "dotenv": "6.2.0",
         "enzyme": "^3.11.0",


### PR DESCRIPTION
- RC: dom-to-image does not support downloading elements
  that do not have style attribute (some els. in KaTex)
  and download failed for grid with latex labels -
  gird in multiplication with extension
- workaround: grid id was moved 'inside' grid itself,
  so that it does not contain axis or labels
- bump cypress to 6.3.0 and add tests for downloading
  grid images
  


I tried to replace `dom-to-image` with `dom-to-image-more` but this still did not fix the issue. Maybye something like `html-to-canvas` will work, but for now this is low prio. This is a workaround, so if this feature is actually used in the future, my reopen this to support downloading axis and labels. 

 closes #111 
