### PR TITLE
UI allows to select wrong algorithm

### DIFF
--- a/apps/calc-web-e2e/src/integration/positional/calculator-options.spec.ts
+++ b/apps/calc-web-e2e/src/integration/positional/calculator-options.spec.ts
@@ -1,0 +1,37 @@
+import { OperationTemplate } from '@calc/positional-calculator';
+import { AlgorithmType, MultiplicationType, OperationType } from '@calc/calc-arithmetic';
+import {
+    getCalculateButton,
+    getMultiplicationResult,
+    getOperationGrid, hasProperResult,
+    operationReturnsProperResult, selectAlgorithm, selectOperation
+} from '../../support/positional-calculator';
+
+describe('Calculator options', () => {
+    beforeEach(() => {
+        cy.fixCypressSpec(__filename);
+        cy.clearLocalStorage();
+        cy.visit('#/tools/positional/positional-calculator');
+    });
+
+    // BUG #110
+    it('should update algorithm to default when operation changes', () => {
+        const config: OperationTemplate<AlgorithmType> = {
+            operands: ['78', '88'],
+            operation: OperationType.Multiplication,
+            algorithm: MultiplicationType.WithExtension,
+            base: 10
+        };
+        const expectedMultiplication = '6864';
+        const expectedAddition = '166';
+
+        // Run some operation
+        operationReturnsProperResult(config, expectedMultiplication);
+
+        // Change algorithm without changing operation
+        selectOperation('Addition');
+        getCalculateButton().click();
+
+        hasProperResult(expectedAddition);
+    });
+});

--- a/libs/calc-arithmetic/src/lib/models/operation-algorithm.ts
+++ b/libs/calc-arithmetic/src/lib/models/operation-algorithm.ts
@@ -19,7 +19,6 @@ export interface OperationAlgorithm<T extends AlgorithmType = AlgorithmType> {
     type: T;
     tKey: string;
     allowedBases?: number[];
-
 }
 
 export type AlgorithmOperationMap = Record<OperationType, OperationAlgorithm[]>

--- a/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
+++ b/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
@@ -63,6 +63,7 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
     const { t } = useTranslation();
     const [operation, setOperation] = useState<Operation>(defaultOperation || allOperations[2]);
     const [algorithm, setAlgorithm] = useState<OperationAlgorithm>(defaultAlgorithm || multiplicationAlgorithms[1]);
+    const [operationAlgorithms, setOperationAlgorithms] = useState<OperationAlgorithm[]>(multiplicationAlgorithms);
     const [errorMessage, setErrorMessage] = useState<string>('');
     const [submitDisabled, setSubmitDisabled] = useState(false);
 
@@ -97,9 +98,7 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
 
     const form = useFormik({ initialValues, validate, onSubmit: handleSubmit});
 
-    const getPossibleAlgorithms = (op: Operation) => {
-        return algorithmMap[op.type] || [];
-    };
+
 
     const handleOperandChange = (newOperands: DndOperand[]) => {
         setOperands(newOperands)
@@ -127,6 +126,15 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
 
     useEffect(() => {
         onOperationChange(operation.type);
+    }, [operation]);
+
+    useEffect(() => {
+        const getPossibleAlgorithms = (op: Operation) => {
+            return algorithmMap[op.type] || [];
+        };
+        const algorithms = getPossibleAlgorithms(operation);
+        setOperationAlgorithms(algorithms);
+        if(algorithms.length) setAlgorithm(algorithms[0]);
     }, [operation]);
 
     useEffect(() => {
@@ -169,7 +177,7 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
                     data-test='algorithm-select'
                     label={t('positionalCalculator.algorithm')}
                     onChange={(value) => setAlgorithm(value)}
-                    options={getPossibleAlgorithms(operation)}
+                    options={operationAlgorithms}
                 />
                 <div className={classes.growSpacer}/>
                 <Tooltip title={errorMessage}>


### PR DESCRIPTION
- RC: algorithms were not updated after
  operation change in calculator options,
  it was detected only now, because before
  all operations had only "Default" algo,
  multiplication has also "With extension"
- fix: add effect for setting possible algorithms
  after operation change, and set selected to
  first possible
  
  closes #110 