### PR TITLE
Grid too wide for mult w.e

### DIFF
--- a/apps/calc-web-e2e/__snapshots__/index.js.snap
+++ b/apps/calc-web-e2e/__snapshots__/index.js.snap
@@ -6458,18 +6458,16 @@ exports[`Multiplication with extension > should multiply number by 0 #0`] = `
 exports[`Multiplication with extension > should multiply number by 0 #1`] = `
 <div class="makeStyles-cellContent-93" id="operation-grid">
   <div class="makeStyles-gridRow-90">
-    <div data-test="operation-grid-0-0" class="makeStyles-defaultCell-98"></div>
-    <div data-test="operation-grid-1-0" class="makeStyles-defaultCell-98"></div>
-    <div data-test="operation-grid-2-0" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-0-0" class="makeStyles-defaultCell-98">
       (0)
     </div>
-    <div data-test="operation-grid-3-0" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-1-0" class="makeStyles-defaultCell-98">
       1
     </div>
-    <div data-test="operation-grid-4-0" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-2-0" class="makeStyles-defaultCell-98">
       2
     </div>
-    <div data-test="operation-grid-5-0" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-3-0" class="makeStyles-defaultCell-98">
       3
     </div>
   </div>
@@ -6487,19 +6485,11 @@ exports[`Multiplication with extension > should multiply number by 0 #1`] = `
     <div
       data-test="operation-grid-2-1"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-    ></div>
-    <div
-      data-test="operation-grid-3-1"
-      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-    ></div>
-    <div
-      data-test="operation-grid-4-1"
-      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
       (0)
     </div>
     <div
-      data-test="operation-grid-5-1"
+      data-test="operation-grid-3-1"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
       0
@@ -6519,19 +6509,11 @@ exports[`Multiplication with extension > should multiply number by 0 #1`] = `
     <div
       data-test="operation-grid-2-2"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-    ></div>
-    <div
-      data-test="operation-grid-3-2"
-      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-    ></div>
-    <div
-      data-test="operation-grid-4-2"
-      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
       (0)
     </div>
     <div
-      data-test="operation-grid-5-2"
+      data-test="operation-grid-3-2"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
       0
@@ -6540,12 +6522,10 @@ exports[`Multiplication with extension > should multiply number by 0 #1`] = `
   <div class="makeStyles-gridRow-90">
     <div data-test="operation-grid-0-3" class="makeStyles-defaultCell-98"></div>
     <div data-test="operation-grid-1-3" class="makeStyles-defaultCell-98"></div>
-    <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-98"></div>
-    <div data-test="operation-grid-3-3" class="makeStyles-defaultCell-98"></div>
-    <div data-test="operation-grid-4-3" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-98">
       (0)
     </div>
-    <div data-test="operation-grid-5-3" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-3-3" class="makeStyles-defaultCell-98">
       0
     </div>
   </div>
@@ -6734,11 +6714,10 @@ exports[`Multiplication with extension > should multiply 0 by number #1`] = `
 <div class="makeStyles-cellContent-93" id="operation-grid">
   <div class="makeStyles-gridRow-90">
     <div data-test="operation-grid-0-0" class="makeStyles-defaultCell-98"></div>
-    <div data-test="operation-grid-1-0" class="makeStyles-defaultCell-98"></div>
-    <div data-test="operation-grid-2-0" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-1-0" class="makeStyles-defaultCell-98">
       (0)
     </div>
-    <div data-test="operation-grid-3-0" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-2-0" class="makeStyles-defaultCell-98">
       0
     </div>
   </div>
@@ -6752,15 +6731,11 @@ exports[`Multiplication with extension > should multiply 0 by number #1`] = `
     <div
       data-test="operation-grid-1-1"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-    ></div>
-    <div
-      data-test="operation-grid-2-1"
-      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
       (0)
     </div>
     <div
-      data-test="operation-grid-3-1"
+      data-test="operation-grid-2-1"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
       9
@@ -6776,15 +6751,11 @@ exports[`Multiplication with extension > should multiply 0 by number #1`] = `
     <div
       data-test="operation-grid-1-2"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-    ></div>
-    <div
-      data-test="operation-grid-2-2"
-      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
       (0)
     </div>
     <div
-      data-test="operation-grid-3-2"
+      data-test="operation-grid-2-2"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
       0
@@ -6792,11 +6763,10 @@ exports[`Multiplication with extension > should multiply 0 by number #1`] = `
   </div>
   <div class="makeStyles-gridRow-90">
     <div data-test="operation-grid-0-3" class="makeStyles-defaultCell-98"></div>
-    <div data-test="operation-grid-1-3" class="makeStyles-defaultCell-98"></div>
-    <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-1-3" class="makeStyles-defaultCell-98">
       (0)
     </div>
-    <div data-test="operation-grid-3-3" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-98">
       0
     </div>
   </div>

--- a/apps/calc-web-e2e/src/integration/positional/multiplication.spec.ts
+++ b/apps/calc-web-e2e/src/integration/positional/multiplication.spec.ts
@@ -1,12 +1,11 @@
 import { OperationTemplate } from '@calc/positional-calculator';
 import { AlgorithmType, MultiplicationType, OperationType } from '@calc/calc-arithmetic';
 import {
+    getCellByCoords,
     getMultiplicationResult,
     getOperationGrid,
-    getOperationGridSaveButton,
     operationReturnsProperResult
 } from '../../support/positional-calculator';
-import { validateImage } from '../../support/image';
 
 describe('Default multiplication', () => {
     beforeEach(() => {
@@ -28,6 +27,15 @@ describe('Default multiplication', () => {
 
         getMultiplicationResult().toMatchSnapshot();
         getOperationGrid().toMatchSnapshot();
+
+        // should display proper popover for addition rows
+        getCellByCoords(5, 4).trigger('mouseover')
+            .getByDataTest('add-at-position')
+            .contains('S_{0}=4');
+
+        getCellByCoords(2, 4).trigger('mouseover')
+            .getByDataTest('add-at-position')
+            .contains('S_{3}=6');
     });
 
     it('should multiply two negative numbers', () => {
@@ -144,18 +152,24 @@ describe('Multiplication with extension', () => {
         getOperationGrid().toMatchSnapshot();
     });
 
-    // #111
-    it('should multiply numbers and download result grid as image', () => {
+    // BUG #125
+    it('should not display any empty columns and should display popover with position result on cell hover', () => {
         const config: OperationTemplate<AlgorithmType> = {
-            operands: ['(0)3156', '(7)6423'],
+            operands: ['12', '8'],
             operation: OperationType.Multiplication,
             algorithm: MultiplicationType.WithExtension,
-            base: 8
+            base: 10
         };
-        const expected = '-4547726';
+        const expected = '96';
 
         operationReturnsProperResult(config, expected);
-        getOperationGridSaveButton().click();
-        validateImage('result.png');
+
+        // desired grid has width of 4 so this cell should not exist
+        getCellByCoords(4, 0).should('not.exist');
+
+        // should display popover with proper content
+        getCellByCoords(3, 3).trigger('mouseover')
+            .getByDataTest('add-at-position')
+            .contains('S_{0}=6')
     });
 });

--- a/apps/calc-web-e2e/src/support/positional-calculator.ts
+++ b/apps/calc-web-e2e/src/support/positional-calculator.ts
@@ -51,3 +51,7 @@ export const operationReturnsProperResult = (config: OperationTemplate<Algorithm
     hasProperResult(result);
 };
 
+export const getCellByCoords = (x: number, y: number) => {
+    return cy.getByDataTest(`operation-grid-${x}-${y}`)
+};
+

--- a/libs/positional-calculator/src/lib/addition/addition-position-result/add-at-position-hover-content.tsx
+++ b/libs/positional-calculator/src/lib/addition/addition-position-result/add-at-position-hover-content.tsx
@@ -42,7 +42,7 @@ export const AddAtPositionHoverContent: FC<P> = ({ positionResult }) => {
     const carryStrWithSign = positionResult.carry.length > 0 ? `${carryStr},\\;` : '';
 
     return (
-        <div>
+        <div data-test="add-at-position">
             {
                 nonZeroOperands.length > 1 &&
                 <div className="opSumRow">

--- a/libs/positional-calculator/src/lib/multiplication/multiplication-grid/multiplication-grid.tsx
+++ b/libs/positional-calculator/src/lib/multiplication/multiplication-grid/multiplication-grid.tsx
@@ -189,7 +189,10 @@ function getTotalWidth(result: MultiplicationResult): number {
 }
 
 function getMinOperandsSpan(operands: MultiplicationOperand[][]): number {
-    const [multiplicand, multiplier] = operands;
+    const [multiplicand, multiplier] = operands.map((row) => {
+        return row.filter(d => !d.isComplementExtension);
+    });
+
     return multiplicand.length + multiplier.length - 1;
 }
 


### PR DESCRIPTION
- RC: grid span was counted with extension digits
  and that resulted in grid that was 1 cell to wide
- Fix: filter complement digits when calculating
  operands span for multiplication
  
closes #125 