### PR TITLE
Addition operands not extended

### DIFF
--- a/apps/calc-web-e2e/__snapshots__/index.js.snap
+++ b/apps/calc-web-e2e/__snapshots__/index.js.snap
@@ -7554,9 +7554,11 @@ exports[`Multiplication without extension > should multiply two negative numbers
   </div>
   <div class="makeStyles-gridRow-90">
     <div data-test="operation-grid-0-3" class="makeStyles-defaultCell-98"></div>
-    <div data-test="operation-grid-1-3" class="makeStyles-defaultCell-98"></div>
-    <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-1-3" class="makeStyles-defaultCell-98">
       (9)
+    </div>
+    <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-98">
+      9
     </div>
     <div data-test="operation-grid-3-3" class="makeStyles-defaultCell-98">
       9
@@ -7582,9 +7584,11 @@ exports[`Multiplication without extension > should multiply two negative numbers
   </div>
   <div class="makeStyles-gridRow-90">
     <div data-test="operation-grid-0-4" class="makeStyles-defaultCell-98"></div>
-    <div data-test="operation-grid-1-4" class="makeStyles-defaultCell-98"></div>
-    <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-1-4" class="makeStyles-defaultCell-98">
       (9)
+    </div>
+    <div data-test="operation-grid-2-4" class="makeStyles-defaultCell-98">
+      9
     </div>
     <div data-test="operation-grid-3-4" class="makeStyles-defaultCell-98">
       9
@@ -7608,9 +7612,11 @@ exports[`Multiplication without extension > should multiply two negative numbers
   </div>
   <div class="makeStyles-gridRow-90">
     <div data-test="operation-grid-0-5" class="makeStyles-defaultCell-98"></div>
-    <div data-test="operation-grid-1-5" class="makeStyles-defaultCell-98"></div>
-    <div data-test="operation-grid-2-5" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-1-5" class="makeStyles-defaultCell-98">
       (9)
+    </div>
+    <div data-test="operation-grid-2-5" class="makeStyles-defaultCell-98">
+      9
     </div>
     <div data-test="operation-grid-3-5" class="makeStyles-defaultCell-98">
       6
@@ -7641,7 +7647,7 @@ exports[`Multiplication without extension > should multiply two negative numbers
       data-test="operation-grid-1-6"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
-      0
+      (0)
     </div>
     <div
       data-test="operation-grid-2-6"
@@ -9069,29 +9075,33 @@ exports[`Multiplication without extension > should multiply positive number by n
     <div
       data-test="operation-grid-4-0"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-    >
-      (7)
-    </div>
+    ></div>
     <div
       data-test="operation-grid-5-0"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
-      4
+      (7)
     </div>
     <div
       data-test="operation-grid-6-0"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
-      6
+      4
     </div>
     <div
       data-test="operation-grid-7-0"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
-      2
+      6
     </div>
     <div
       data-test="operation-grid-8-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      2
+    </div>
+    <div
+      data-test="operation-grid-9-0"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
     >
       2
@@ -9102,20 +9112,21 @@ exports[`Multiplication without extension > should multiply positive number by n
     <div data-test="operation-grid-1-1" class="makeStyles-defaultCell-98"></div>
     <div data-test="operation-grid-2-1" class="makeStyles-defaultCell-98"></div>
     <div data-test="operation-grid-3-1" class="makeStyles-defaultCell-98"></div>
-    <div data-test="operation-grid-4-1" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-4-1" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-5-1" class="makeStyles-defaultCell-98">
       (0)
     </div>
-    <div data-test="operation-grid-5-1" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-6-1" class="makeStyles-defaultCell-98">
       3
     </div>
-    <div data-test="operation-grid-6-1" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-7-1" class="makeStyles-defaultCell-98">
       1
     </div>
-    <div data-test="operation-grid-7-1" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-8-1" class="makeStyles-defaultCell-98">
       5
     </div>
     <div
-      data-test="operation-grid-8-1"
+      data-test="operation-grid-9-1"
       class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
     >
       6
@@ -9147,23 +9158,27 @@ exports[`Multiplication without extension > should multiply positive number by n
     <div
       data-test="operation-grid-5-2"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-    >
-      6
-    </div>
+    ></div>
     <div
       data-test="operation-grid-6-2"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
-      4
+      6
     </div>
     <div
       data-test="operation-grid-7-2"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
-      2
+      4
     </div>
     <div
       data-test="operation-grid-8-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    >
+      2
+    </div>
+    <div
+      data-test="operation-grid-9-2"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
     >
       3
@@ -9181,19 +9196,22 @@ exports[`Multiplication without extension > should multiply positive number by n
       0
     </div>
     <div data-test="operation-grid-4-3" class="makeStyles-defaultCell-98">
-      1
+      0
     </div>
     <div data-test="operation-grid-5-3" class="makeStyles-defaultCell-98">
       1
     </div>
     <div data-test="operation-grid-6-3" class="makeStyles-defaultCell-98">
-      5
+      1
     </div>
     <div data-test="operation-grid-7-3" class="makeStyles-defaultCell-98">
+      5
+    </div>
+    <div data-test="operation-grid-8-3" class="makeStyles-defaultCell-98">
       1
     </div>
     <div
-      data-test="operation-grid-8-3"
+      data-test="operation-grid-9-3"
       class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
     >
       2
@@ -9211,19 +9229,22 @@ exports[`Multiplication without extension > should multiply positive number by n
       0
     </div>
     <div data-test="operation-grid-4-4" class="makeStyles-defaultCell-98">
-      6
+      0
     </div>
     <div data-test="operation-grid-5-4" class="makeStyles-defaultCell-98">
-      3
+      6
     </div>
     <div data-test="operation-grid-6-4" class="makeStyles-defaultCell-98">
       3
     </div>
     <div data-test="operation-grid-7-4" class="makeStyles-defaultCell-98">
+      3
+    </div>
+    <div data-test="operation-grid-8-4" class="makeStyles-defaultCell-98">
       4
     </div>
     <div
-      data-test="operation-grid-8-4"
+      data-test="operation-grid-9-4"
       class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
     ></div>
   </div>
@@ -9233,23 +9254,26 @@ exports[`Multiplication without extension > should multiply positive number by n
       (0)
     </div>
     <div data-test="operation-grid-2-5" class="makeStyles-defaultCell-98">
-      1
-    </div>
-    <div data-test="operation-grid-3-5" class="makeStyles-defaultCell-98">
-      4
-    </div>
-    <div data-test="operation-grid-4-5" class="makeStyles-defaultCell-98">
-      6
-    </div>
-    <div data-test="operation-grid-5-5" class="makeStyles-defaultCell-98">
-      7
-    </div>
-    <div data-test="operation-grid-6-5" class="makeStyles-defaultCell-98">
       0
     </div>
-    <div data-test="operation-grid-7-5" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-3-5" class="makeStyles-defaultCell-98">
+      1
+    </div>
+    <div data-test="operation-grid-4-5" class="makeStyles-defaultCell-98">
+      4
+    </div>
+    <div data-test="operation-grid-5-5" class="makeStyles-defaultCell-98">
+      6
+    </div>
+    <div data-test="operation-grid-6-5" class="makeStyles-defaultCell-98">
+      7
+    </div>
+    <div data-test="operation-grid-7-5" class="makeStyles-defaultCell-98">
+      0
+    </div>
+    <div data-test="operation-grid-8-5" class="makeStyles-defaultCell-98"></div>
     <div
-      data-test="operation-grid-8-5"
+      data-test="operation-grid-9-5"
       class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
     ></div>
   </div>
@@ -9264,19 +9288,19 @@ exports[`Multiplication without extension > should multiply positive number by n
       data-test="operation-grid-1-6"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
-      7
+      (7)
     </div>
     <div
       data-test="operation-grid-2-6"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
-      1
+      7
     </div>
     <div
       data-test="operation-grid-3-6"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
-      4
+      1
     </div>
     <div
       data-test="operation-grid-4-6"
@@ -9293,13 +9317,19 @@ exports[`Multiplication without extension > should multiply positive number by n
     <div
       data-test="operation-grid-6-6"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-    ></div>
+    >
+      4
+    </div>
     <div
       data-test="operation-grid-7-6"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     ></div>
     <div
       data-test="operation-grid-8-6"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-9-6"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
     ></div>
   </div>
@@ -9309,25 +9339,28 @@ exports[`Multiplication without extension > should multiply positive number by n
       (7)
     </div>
     <div data-test="operation-grid-2-7" class="makeStyles-defaultCell-98">
-      3
+      7
     </div>
     <div data-test="operation-grid-3-7" class="makeStyles-defaultCell-98">
-      2
-    </div>
-    <div data-test="operation-grid-4-7" class="makeStyles-defaultCell-98">
       3
     </div>
+    <div data-test="operation-grid-4-7" class="makeStyles-defaultCell-98">
+      2
+    </div>
     <div data-test="operation-grid-5-7" class="makeStyles-defaultCell-98">
-      0
+      3
     </div>
     <div data-test="operation-grid-6-7" class="makeStyles-defaultCell-98">
       0
     </div>
     <div data-test="operation-grid-7-7" class="makeStyles-defaultCell-98">
+      0
+    </div>
+    <div data-test="operation-grid-8-7" class="makeStyles-defaultCell-98">
       5
     </div>
     <div
-      data-test="operation-grid-8-7"
+      data-test="operation-grid-9-7"
       class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
     >
       2
@@ -10033,29 +10066,33 @@ exports[`Multiplication without extension > should multiply numbers with fractio
     <div
       data-test="operation-grid-4-0"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-5-0"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
       (7)
     </div>
     <div
-      data-test="operation-grid-5-0"
+      data-test="operation-grid-6-0"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
       4
     </div>
     <div
-      data-test="operation-grid-6-0"
+      data-test="operation-grid-7-0"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
     >
       6
     </div>
     <div
-      data-test="operation-grid-7-0"
+      data-test="operation-grid-8-0"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
       6
     </div>
     <div
-      data-test="operation-grid-8-0"
+      data-test="operation-grid-9-0"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
     >
       6
@@ -10066,23 +10103,24 @@ exports[`Multiplication without extension > should multiply numbers with fractio
     <div data-test="operation-grid-1-1" class="makeStyles-defaultCell-98"></div>
     <div data-test="operation-grid-2-1" class="makeStyles-defaultCell-98"></div>
     <div data-test="operation-grid-3-1" class="makeStyles-defaultCell-98"></div>
-    <div data-test="operation-grid-4-1" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-4-1" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-5-1" class="makeStyles-defaultCell-98">
       (0)
     </div>
-    <div data-test="operation-grid-5-1" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-6-1" class="makeStyles-defaultCell-98">
       3
     </div>
     <div
-      data-test="operation-grid-6-1"
+      data-test="operation-grid-7-1"
       class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
     >
       1
     </div>
-    <div data-test="operation-grid-7-1" class="makeStyles-defaultCell-98">
+    <div data-test="operation-grid-8-1" class="makeStyles-defaultCell-98">
       1
     </div>
     <div
-      data-test="operation-grid-8-1"
+      data-test="operation-grid-9-1"
       class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
     >
       2
@@ -10114,23 +10152,27 @@ exports[`Multiplication without extension > should multiply numbers with fractio
     <div
       data-test="operation-grid-5-2"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-6-2"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
       6
     </div>
     <div
-      data-test="operation-grid-6-2"
+      data-test="operation-grid-7-2"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
     >
       4
     </div>
     <div
-      data-test="operation-grid-7-2"
+      data-test="operation-grid-8-2"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
       0
     </div>
     <div
-      data-test="operation-grid-8-2"
+      data-test="operation-grid-9-2"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
     >
       0
@@ -10159,8 +10201,11 @@ exports[`Multiplication without extension > should multiply numbers with fractio
     <div data-test="operation-grid-7-3" class="makeStyles-defaultCell-98">
       0
     </div>
+    <div data-test="operation-grid-8-3" class="makeStyles-defaultCell-98">
+      0
+    </div>
     <div
-      data-test="operation-grid-8-3"
+      data-test="operation-grid-9-3"
       class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
     >
       0
@@ -10189,8 +10234,11 @@ exports[`Multiplication without extension > should multiply numbers with fractio
     <div data-test="operation-grid-7-4" class="makeStyles-defaultCell-98">
       0
     </div>
+    <div data-test="operation-grid-8-4" class="makeStyles-defaultCell-98">
+      0
+    </div>
     <div
-      data-test="operation-grid-8-4"
+      data-test="operation-grid-9-4"
       class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
     ></div>
   </div>
@@ -10200,23 +10248,26 @@ exports[`Multiplication without extension > should multiply numbers with fractio
       (0)
     </div>
     <div data-test="operation-grid-2-5" class="makeStyles-defaultCell-98">
-      1
+      0
     </div>
     <div data-test="operation-grid-3-5" class="makeStyles-defaultCell-98">
-      4
+      1
     </div>
     <div data-test="operation-grid-4-5" class="makeStyles-defaultCell-98">
       4
     </div>
     <div data-test="operation-grid-5-5" class="makeStyles-defaultCell-98">
-      5
+      4
     </div>
     <div data-test="operation-grid-6-5" class="makeStyles-defaultCell-98">
+      5
+    </div>
+    <div data-test="operation-grid-7-5" class="makeStyles-defaultCell-98">
       0
     </div>
-    <div data-test="operation-grid-7-5" class="makeStyles-defaultCell-98"></div>
+    <div data-test="operation-grid-8-5" class="makeStyles-defaultCell-98"></div>
     <div
-      data-test="operation-grid-8-5"
+      data-test="operation-grid-9-5"
       class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
     ></div>
   </div>
@@ -10231,19 +10282,19 @@ exports[`Multiplication without extension > should multiply numbers with fractio
       data-test="operation-grid-1-6"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
-      7
+      (7)
     </div>
     <div
       data-test="operation-grid-2-6"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
-      1
+      7
     </div>
     <div
       data-test="operation-grid-3-6"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
-      5
+      1
     </div>
     <div
       data-test="operation-grid-4-6"
@@ -10255,18 +10306,24 @@ exports[`Multiplication without extension > should multiply numbers with fractio
       data-test="operation-grid-5-6"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     >
-      4
+      5
     </div>
     <div
       data-test="operation-grid-6-6"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
-    ></div>
+    >
+      4
+    </div>
     <div
       data-test="operation-grid-7-6"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
     ></div>
     <div
       data-test="operation-grid-8-6"
+      class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104"
+    ></div>
+    <div
+      data-test="operation-grid-9-6"
       class="makeStyles-defaultCell-98 makeStyles-horizontalLine-104 makeStyles-verticalLine-105"
     ></div>
   </div>
@@ -10276,28 +10333,31 @@ exports[`Multiplication without extension > should multiply numbers with fractio
       (7)
     </div>
     <div data-test="operation-grid-2-7" class="makeStyles-defaultCell-98">
-      3
+      7
     </div>
     <div data-test="operation-grid-3-7" class="makeStyles-defaultCell-98">
+      3
+    </div>
+    <div data-test="operation-grid-4-7" class="makeStyles-defaultCell-98">
       2
     </div>
     <div
-      data-test="operation-grid-4-7"
+      data-test="operation-grid-5-7"
       class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
     >
       2
     </div>
-    <div data-test="operation-grid-5-7" class="makeStyles-defaultCell-98">
-      1
-    </div>
     <div data-test="operation-grid-6-7" class="makeStyles-defaultCell-98">
-      0
+      1
     </div>
     <div data-test="operation-grid-7-7" class="makeStyles-defaultCell-98">
       0
     </div>
+    <div data-test="operation-grid-8-7" class="makeStyles-defaultCell-98">
+      0
+    </div>
     <div
-      data-test="operation-grid-8-7"
+      data-test="operation-grid-9-7"
       class="makeStyles-defaultCell-98 makeStyles-verticalLine-105"
     >
       0

--- a/apps/calc-web-e2e/src/integration/positional/multiplication.spec.ts
+++ b/apps/calc-web-e2e/src/integration/positional/multiplication.spec.ts
@@ -247,7 +247,7 @@ describe('Multiplication without extension', () => {
         getOperationGrid().toMatchSnapshot();
 
         // should display popover with proper content
-        getCellByCoords(8, 7).trigger('mouseover')
+        getCellByCoords(9, 7).trigger('mouseover')
             .getByDataTest('add-at-position')
             .contains('S_{0}=2');
     });

--- a/libs/calc-arithmetic/src/lib/positional/multiplication/multiplication-with-extension.ts
+++ b/libs/calc-arithmetic/src/lib/positional/multiplication/multiplication-with-extension.ts
@@ -4,6 +4,7 @@ import { getComplement } from '../complement-converter';
 import { addDigitsArrays, mergeAdditionExtensionDigit } from '../addition';
 import { PositionalNumber } from '../positional-number';
 import {
+    AdditionOperand,
     Digit,
     MultiplicationOperand,
     MultiplicationPositionResult,
@@ -73,7 +74,7 @@ function extendComplementToPosition<T extends Digit>(complement: T[], numRows: n
     return extendComplement(complement, numPositionsToExtend);
 }
 
-function extendComplementsToPosition(complements: MultiplicationOperand[][], maxPositionAfterExtend: number) {
+function extendComplementsToPosition<T extends Digit>(complements: T[][], maxPositionAfterExtend: number) {
     const merged = complements.map(mergeExtensionDigits);
     const numRows = complements.length;
 
@@ -82,12 +83,12 @@ function extendComplementsToPosition(complements: MultiplicationOperand[][], max
     });
 }
 
-export function shiftAndExtend(rowDigits: MultiplicationRowResult[]) {
-    const globalMostSignificant = Math.max(...rowDigits.map(r => r.resultDigits[0].position));
-    const maxPositionAfterExtend = globalMostSignificant + rowDigits.length - 1;
+export function shiftAndExtend<T extends Digit>(operands: T[][]) {
+    const globalMostSignificant = Math.max(...operands.map(r => r[0].position));
+    const maxPositionAfterExtend = globalMostSignificant + operands.length - 1;
 
-    const shiftedRows = rowDigits.map((result, index) => {
-        return shiftLeft(result.resultDigits, index);
+    const shiftedRows = operands.map((opRow, index) => {
+        return shiftLeft(opRow, index);
     });
 
     return extendComplementsToPosition(shiftedRows, maxPositionAfterExtend);
@@ -106,7 +107,7 @@ function multiplyDigitRows(
         return multiplyRowByDigit(multiplicandRow, multiplier);
     });
 
-    const rowResultDigits = shiftAndExtend(rowResults);
+    const rowResultDigits = shiftAndExtend(rowResults.map(res => res.resultDigits));
 
     let multiplicandComplement: PositionalNumber;
 

--- a/libs/calc-arithmetic/src/lib/positional/multiplication/multiplication-without-extension.ts
+++ b/libs/calc-arithmetic/src/lib/positional/multiplication/multiplication-without-extension.ts
@@ -51,7 +51,7 @@ function multiplyDigitRows(
         return multiplyRowByDigit(multiplicandRow, multiplier);
     });
 
-    const rowResultDigits = shiftAndExtend(rowResults);
+    const digitsToShift = rowResults.map(r => r.resultDigits);
 
     let multiplicandComplement: PositionalNumber;
 
@@ -66,14 +66,14 @@ function multiplyDigitRows(
 
         const complement = getComplement(new NumberComplement(multiplicandDigits));
         const lastDigits = multiplyRowByDigit(complement.asDigits(), absDigit).resultDigits;
-        const numPositionsToShift = rowResultDigits.length;
-        const shifted = shiftLeft(lastDigits, numPositionsToShift);
 
-        rowResultDigits.push(shifted);
+        digitsToShift.push(lastDigits);
         multiplicandComplement = fromDigits(complement.asDigits()).result;
     }
 
-    const sum = addDigitsArrays(rowResultDigits);
+    const shifted = shiftAndExtend(digitsToShift);
+
+    const sum = addDigitsArrays(shifted);
     const adjustedSum = adjustForMultiplierFraction(sum, multiplierRow);
     const trimmedLeadingZeros = trimSumDigits(adjustedSum.numberResult.asDigits());
     const resultWithProperSign = fromDigits(trimmedLeadingZeros, resultNegative).result;


### PR DESCRIPTION
- RC: for mult w/out.ext row results were aligned before
  correction was added, and correction can sometimes
  have more digits than row results (ex. 6 * -M)
  This worked for mult w.ext because there the correction
  alwas has same num of digits as M
- Fix: move extending addition operands after correction
  is added to operand array
  
  closes #130 