### PR TITLE
Addition grid crashes on hover

### DIFF
--- a/apps/calc-web-e2e/src/integration/positional/addition.spec.ts
+++ b/apps/calc-web-e2e/src/integration/positional/addition.spec.ts
@@ -70,7 +70,7 @@ describe('Addition', () => {
     });
 
     // STUD_REQ_5_3
-    it.only('should show proper position details and carries', () => {
+    it('should show proper position details and carries', () => {
         const base = 10;
         const config: OperationTemplate<AlgorithmType> = {
             operands: ['987', '6354'],
@@ -145,4 +145,23 @@ describe('Addition', () => {
         getAdditionResult().toMatchSnapshot();
         getOperationGrid().toMatchSnapshot();
     });
+
+
+    // BUG #140
+    it('should not crash when addition position results has only zero operands', () => {
+        const config: OperationTemplate<AlgorithmType> = {
+            operands:  ['111', '111', '111', '110', '110'],
+            operation: OperationType.Addition,
+            algorithm: AdditionType.Default,
+            base: 2
+        };
+
+        const expected = '100001';
+
+        operationReturnsProperResult(config, expected);
+
+        getCellByCoords(0, 0).trigger('mouseover')
+            .getByDataTest('add-at-position')
+            .contains('S_{7}=0');
+    })
 });

--- a/libs/positional-calculator/src/lib/addition/addition-position-result/add-at-position-hover-content.tsx
+++ b/libs/positional-calculator/src/lib/addition/addition-position-result/add-at-position-hover-content.tsx
@@ -31,7 +31,7 @@ function carriesToLatexStr(carries: AdditionOperand[]): string {
 export const AddAtPositionHoverContent: FC<P> = ({ positionResult }) => {
     if (!positionResult || !positionResult.operands) return null;
 
-    const posSum = fromNumber(positionResult.decimalSum, positionResult.operands[0].base).result.toString();
+    const posSum = fromNumber(positionResult.decimalSum, positionResult.valueAtPosition.base).result.toString();
 
     const nonZeroOperands = positionResult.operands.filter((op) => op.valueInDecimal !== 0);
     const operandsStr = operandsToLatexStr(nonZeroOperands);


### PR DESCRIPTION
- RC: zero operands are filtered in position results
  for display, so multiple position additions do not
  show all the + 0 + 0... additions, but also the
  base prop needed for building hover content was
  taken from first operand, and if the array was empty
  app crashed
- Fix: take the base prop, from valueAtPosition which is
  always defined
  
  closes #140 