### PR TITLE
Calculate button disabled

### DIFF
--- a/apps/calc-web-e2e/src/integration/positional/addition.spec.ts
+++ b/apps/calc-web-e2e/src/integration/positional/addition.spec.ts
@@ -106,7 +106,6 @@ describe('Addition', () => {
         gridHasProperResultRow(expected, base, 5, 3);
     });
 
-
     // STUD_REQ_5_4
     it('should add multiple binary numbers together', () => {
         const config: OperationTemplate<AlgorithmType> = {

--- a/apps/calc-web-e2e/src/integration/positional/calculator-options.spec.ts
+++ b/apps/calc-web-e2e/src/integration/positional/calculator-options.spec.ts
@@ -81,4 +81,19 @@ describe('Calculator options', () => {
         getAddOperandButton().trigger('mouseover', { force: true });
         getCommonTooltip().contains(message);
     });
+
+    // BUG #145
+    it('should enable calculation when base was changed to match operands', () => {
+        const base = 2;
+        const operands = ['(1)010101', '(0)1101'];
+
+        // Default base is 10, enter operands
+        selectOperation('Multiplication');
+        addOperands(operands);
+        getCalculateButton().should('be.disabled');
+
+        // Update base to match operands
+        setOperationBase(base);
+        getCalculateButton().should('be.enabled');
+    });
 });

--- a/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
+++ b/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
@@ -3,7 +3,7 @@ import { ExtendedSelect, FormErrors } from '@calc/common-ui';
 import {
     algorithmMap,
     allOperations,
-    BaseDigits, multiplicationAlgorithms,
+    BaseDigits, isValidComplementOrRepresentationStr, multiplicationAlgorithms,
     Operation,
     OperationAlgorithm,
     OperationType
@@ -98,10 +98,14 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
 
     const form = useFormik({ initialValues, validate, onSubmit: handleSubmit});
 
-
-
     const handleOperandChange = (newOperands: DndOperand[]) => {
-        setOperands(newOperands)
+        const ops: DndOperand[] = newOperands.map((op: DndOperand) => {
+            return {
+                ...op,
+                valid: isValidComplementOrRepresentationStr(op.representation, form.values.base)
+            }
+        });
+        setOperands(ops);
     };
 
     const handleAdd = () => {
@@ -143,7 +147,7 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
     }, [operands, operation]);
 
     useEffect(() => {
-        const disabled = !form.isValid || operands.length < 1 || !canCalculate;
+        const disabled = operands.length < 1 || !canCalculate;
         setSubmitDisabled(disabled);
     }, [form.isValid, operands, canCalculate]);
 

--- a/libs/positional-calculator/src/lib/operand-input/operand-input.tsx
+++ b/libs/positional-calculator/src/lib/operand-input/operand-input.tsx
@@ -31,7 +31,7 @@ export const OperandInput: FC<P> = ({ representationStr, onRepresentationChange,
                 );
             }
         };
-        const err = validateValueStr(representation, base);
+        const err = !!validateValueStr(representation, base);
         setError(validateValueStr(representation, base));
         onRepresentationChange(representation, index, !err)
     }, [base, representation]);

--- a/libs/positional-calculator/src/lib/operand-list/operand-list.tsx
+++ b/libs/positional-calculator/src/lib/operand-list/operand-list.tsx
@@ -76,7 +76,6 @@ export const OperandList: FC<P> = ({ inputBase, operands, onChange, onAdd, canAd
         onChange(newArr);
     };
 
-
     const handleChange = (representationStr: string, index: number, isValid: boolean) => {
         const newOperands = [...operands];
         newOperands[index] = { ...newOperands[index], representation: representationStr, valid: isValid };
@@ -88,6 +87,7 @@ export const OperandList: FC<P> = ({ inputBase, operands, onChange, onAdd, canAd
             <Draggable key={item.dndKey} draggableId={`${item.dndKey}`} index={index}>
                 {(provided, snapshot) => (
                     <OperandInput
+                        inputKey={item.dndKey}
                         dataTest={`operand-input-${index}`}
                         ContainerComponent="li"
                         ContainerProps={{ ref: provided.innerRef }}


### PR DESCRIPTION
- RC: when base changes operand list calls on change properly with
  all operands valid, but there's additonal on change call with
  valid set to false, not sure how, maybe hooks + props passed
  options -> list -> input lag a bit
- Fix: none real for now, workaround is to validate representations
  again on change handler in calculator options