### PR TITLE
Wrong result for multiplication by 0.1

### DIFF
--- a/libs/calc-arithmetic/src/lib/positional/multiplication/with-extension.spec.ts
+++ b/libs/calc-arithmetic/src/lib/positional/multiplication/with-extension.spec.ts
@@ -121,5 +121,22 @@ describe('multiply-with-extensions', () => {
             expect(result.numberResult.toString()).toEqual(expected);
             expect(result.numberResult.complement.toString()).toEqual(expectedComplement);
         });
+
+        // BUG #158
+        it('should multiply 1 in U2 by number between 0 and 1', () => {
+            // given
+            const base = 2;
+            const x = fromStringDirect('1', base).result;
+            const y = fromStringDirect('0.1', base).result;
+
+            // when
+            const result = multiplyWithExtensions([x, y]);
+
+            // then
+            const expected = '0.1';
+            const expectedComplement = '(0)0.1';
+            expect(result.numberResult.toString()).toEqual(expected);
+            expect(result.numberResult.complement.toString()).toEqual(expectedComplement);
+        });
     });
 });

--- a/libs/calc-arithmetic/src/lib/positional/multiplication/with-extension.ts
+++ b/libs/calc-arithmetic/src/lib/positional/multiplication/with-extension.ts
@@ -122,9 +122,12 @@ export class WithExtension extends DefaultMultiplication {
         const onlyZeros = digits.every(isZeroDigit);
         return onlyZeros
             ? digits
-            : trimStartByPredicate(digits, isZeroDigit);
+            : trimStartByPredicate(digits, this.isZeroDigitOnGreaterThanZeroPosition);
     }
 
+    private isZeroDigitOnGreaterThanZeroPosition(digit: Digit): boolean {
+        return digit.position > 0 && isZeroDigit(digit);
+    }
 
     private getPositionCap(multiplicandRow: MultiplicationOperand[], multiplierRow: MultiplicationOperand[]): number {
         const multiplicandLSP = leastSignificantPosition(multiplicandRow);

--- a/libs/positional-calculator/src/lib/core/sanity-check.ts
+++ b/libs/positional-calculator/src/lib/core/sanity-check.ts
@@ -2,7 +2,7 @@ import { OperationParams } from './calculate';
 import { AlgorithmType, fromNumber, OperationType, PositionalNumber } from '@calc/calc-arithmetic';
 import BigNumber from 'bignumber.js';
 
-interface SanityCheck<T extends AlgorithmType> {
+export interface SanityCheck<T extends AlgorithmType> {
     params: OperationParams<T>;
     actual: PositionalNumber;
     expectedDecimal: number | BigNumber;
@@ -12,14 +12,16 @@ interface SanityCheck<T extends AlgorithmType> {
 
 export function serializeForSentry<T extends AlgorithmType>(check: SanityCheck<T>): Record<string, unknown> {
     return {
-        actualInBase: check.actual.toString(),
-        actualInDecimal: check.actual.decimalValue.toString(),
-        expectedInDecimal: check.expectedDecimal,
-        expectedInBase: fromNumber(check.expectedDecimal, check.params.base).result.toString(),
-        operation: check.params.operation.type,
-        algorithm: check.params.algorithm.type,
-        base: check.params.base,
-        operands: check.params.operands.map(op => op.toString())
+       extra: {
+           actualInBase: check.actual.toString(),
+           actualInDecimal: check.actual.decimalValue.toString(),
+           expectedInDecimal: check.expectedDecimal,
+           expectedInBase: fromNumber(check.expectedDecimal, check.params.base).result.toString(),
+           operation: check.params.operation.type,
+           algorithm: check.params.algorithm.type,
+           base: check.params.base,
+           operands: check.params.operands.map(op => op.toString())
+       }
     }
 }
 

--- a/libs/positional-calculator/src/lib/positional-calculator-view/positional-calculator-view.tsx
+++ b/libs/positional-calculator/src/lib/positional-calculator-view/positional-calculator-view.tsx
@@ -17,7 +17,7 @@ import { CalculatorOptions } from '../calculator-options/calculator-options';
 import { getGroupBuilder } from '../core/operation-group-builer';
 import { OperationResultComponent } from '../operation-result/operation-result';
 import { calculate, GridResult, OperationParams } from '../core/calculate';
-import { SanityCheck } from '../sanity-check/sanity-check';
+import { SanityCheckFailed } from '../sanity-check/sanity-check-failed';
 import { sanityCheck, serializeForSentry } from '../core/sanity-check';
 import * as Sentry from '@sentry/react';
 
@@ -52,7 +52,7 @@ export const PositionalCalculatorView: FC = () => {
     const classes = useStyles();
     const [sanityCheckFailed, setSanityCheckFailed] = useState(false);
     const [errorOpen, setErrorOpen] = useState(false);
-    const [expected, setExepected] = useState('');
+    const [expected, setExpected] = useState('');
     const [actual, setActual] = useState('');
     const [operation, setOperation] = useState<OperationType>(OperationType.Addition);
     const { t } = useTranslation();
@@ -88,7 +88,7 @@ export const PositionalCalculatorView: FC = () => {
             Sentry.captureException(new Error(msg), {extra});
             setSanityCheckFailed(true);
             setErrorOpen(true);
-            setExepected(check.expectedInBase);
+            setExpected(check.expectedInBase);
             setActual(check.actual.toString());
         }
         setRes(res);
@@ -108,10 +108,7 @@ export const PositionalCalculatorView: FC = () => {
     const theoryPath = operation ? `/theory/positional/operations/${operation.toLowerCase()}` : '/theory/positional/operations';
 
     const handleClose = (event?: SyntheticEvent, reason?: string) => {
-        if (reason === 'clickaway') {
-            return;
-        }
-
+        if (reason === 'clickaway') return;
         setErrorOpen(false);
     };
 
@@ -149,7 +146,7 @@ export const PositionalCalculatorView: FC = () => {
                 anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
                 open={errorOpen}
             >
-               <SanityCheck onClose={handleClose} expected={expected} actual={actual}/>
+               <SanityCheckFailed onClose={handleClose} expected={expected} actual={actual}/>
             </Snackbar>
         </ViewWrapper>
     );

--- a/libs/positional-calculator/src/lib/sanity-check/sanity-check-failed.tsx
+++ b/libs/positional-calculator/src/lib/sanity-check/sanity-check-failed.tsx
@@ -8,7 +8,7 @@ interface P {
     onClose: () => void;
 }
 
-export const SanityCheck: FC<P> = ({expected, actual, onClose}) => {
+export const SanityCheckFailed: FC<P> = ({expected, actual, onClose}) => {
     const {t} = useTranslation();
 
     return (


### PR DESCRIPTION
- RC: for wext/woutext multiplication, the result is
  stripped of leading zeros, so for example, 00011.01
  is converted to 11.01. However, this also stripped leading
  zeros from results between 0 and 1, ex. 0.1101 was converted
  to 1101
- Fix: modify strip predicate to strip only zeros at positions
  greater than 0
  
  closes #158 