### PR TITLE
Unexpected error while multiplying:

### DIFF
--- a/libs/calc-arithmetic/src/lib/helpers/conversion-helpers.spec.ts
+++ b/libs/calc-arithmetic/src/lib/helpers/conversion-helpers.spec.ts
@@ -711,6 +711,18 @@ describe('conversion-helpers', () => {
             const expected = '-12 45.34 56';
             expect(result).toEqual(expected)
         });
+
+        it('should strip extraneous spaces around delimiter', () => {
+            // given
+            const representation = '−12 45 . 34  56  ';
+
+            // when
+            const result = serializeRepresentationStr(representation);
+
+            // then
+            const expected = '-12 45.34 56';
+            expect(result).toEqual(expected)
+        });
     });
 
     describe('#digitsToStr', () => {

--- a/libs/calc-arithmetic/src/lib/helpers/conversion-helpers.ts
+++ b/libs/calc-arithmetic/src/lib/helpers/conversion-helpers.ts
@@ -278,6 +278,9 @@ export function serializeRepresentationStr(representation: string): string {
         .replace('−', '-')
         .replace(',', '.')
         .replace(/\s+/g, ' ')
+        .replace('. ', '.')
+        .replace(' . ', '.')
+        .replace(' .', '.')
         .trim();
 }
 

--- a/libs/calc-arithmetic/src/lib/positional/base-converter.spec.ts
+++ b/libs/calc-arithmetic/src/lib/positional/base-converter.spec.ts
@@ -450,6 +450,37 @@ describe('base-converter', () => {
             expect(result.decimalValue).toEqual(expectedValue);
         });
 
+        it('converts positive base64 with fraction part', () => {
+            // given
+            const input = '01.23';
+            const inputbase = 64;
+            const expectedValue = new BigNumber(1.359375);
+
+            // when
+            const conv = BaseConverter.fromStringDirect(input, inputbase);
+            const result = conv.result;
+
+            // then
+            expect(result.valueInBase).toEqual(input);
+            expect(result.decimalValue).toEqual(expectedValue);
+        });
+
+        it('converts positive base64 with fraction part with additional spaces', () => {
+            // given
+            const input = '01. 23';
+            const inputbase = 64;
+            const expectedValue = new BigNumber(1.359375);
+
+            // when
+            const conv = BaseConverter.fromStringDirect(input, inputbase);
+            const result = conv.result;
+
+            // then
+            const expectedInput = '01.23';
+            expect(result.valueInBase).toEqual(expectedInput);
+            expect(result.decimalValue).toEqual(expectedValue);
+        });
+
         it('converts negative base64', () => {
             // given
             const input = '-32 18.19';

--- a/libs/calc-arithmetic/src/lib/positional/base-converter.ts
+++ b/libs/calc-arithmetic/src/lib/positional/base-converter.ts
@@ -213,7 +213,7 @@ export class StandardBaseConverter implements BaseConverter {
         resultBase: number,
         precision = 30
     ): Conversion {
-        let valueStr = inputStr;
+        let valueStr = serializeRepresentationStr(inputStr);
         let inputSourceType = PositionalSourceType.RepresentationStr;
 
         if(isValidComplementStr(valueStr, inputBase)) {
@@ -254,7 +254,7 @@ export class StandardBaseConverter implements BaseConverter {
         inputStr: string,
         inputBase: number
     ): Conversion {
-        let valueStr = inputStr;
+        let valueStr = serializeRepresentationStr(inputStr);
         let inputType = PositionalSourceType.RepresentationStr;
 
         if(isValidComplementStr(valueStr, inputBase)) {
@@ -317,8 +317,7 @@ export function fromString(
     precision = 30,
     converter: BaseConverter = new StandardBaseConverter()
 ): Conversion {
-    const serializedStr = serializeRepresentationStr(valueStr);
-    return converter.fromString(serializedStr, inputBase, resultBase, precision);
+    return converter.fromString(valueStr, inputBase, resultBase, precision);
 }
 
 export function fromStringDirect(
@@ -326,8 +325,7 @@ export function fromStringDirect(
     inputBase: number
 ): Conversion {
     const converter = new StandardBaseConverter();
-    const serializedStr = serializeRepresentationStr(valueStr);
-    return converter.fromStringDirect(serializedStr, inputBase);
+    return converter.fromStringDirect(valueStr, inputBase);
 }
 
 export function fromDigits(

--- a/libs/calc-arithmetic/src/lib/positional/multiplication/with-extension.spec.ts
+++ b/libs/calc-arithmetic/src/lib/positional/multiplication/with-extension.spec.ts
@@ -138,5 +138,22 @@ describe('multiply-with-extensions', () => {
             expect(result.numberResult.toString()).toEqual(expected);
             expect(result.numberResult.complement.toString()).toEqual(expectedComplement);
         });
+
+        // BUG #162
+        it('should multiply 2 b64 numbers in with fraction parts', () => {
+            // given
+            const base = 64;
+            const x = fromStringDirect('12. 34', base).result;
+            const y = fromStringDirect('11 08', base).result;
+
+            // when
+            const result = multiplyWithExtensions([x, y]);
+
+            // then
+            const expected = '02 11 26.16';
+            const expectedComplement = '(00) 02 11 26.16';
+            expect(result.numberResult.toString()).toEqual(expected);
+            expect(result.numberResult.complement.toString()).toEqual(expectedComplement);
+        });
     });
 });


### PR DESCRIPTION
- RC: when b64 representation was entered with additional
  spaces around fraction part delimiter (ex. 23 45. 45)
  the parsing failed silently, and set that number decimal
  value to NaN
- Fix: add more conditions to serializeRepresentationStr()
  so all of the possible delimiter variants are handled

closes #162 