### PR TITLE
Group results shifted on hover:

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "printWidth": 120
 }

--- a/apps/calc-web-e2e/src/integration/positional/multiplication/booth-mcsorley-multiplication.spec.ts
+++ b/apps/calc-web-e2e/src/integration/positional/multiplication/booth-mcsorley-multiplication.spec.ts
@@ -1,9 +1,5 @@
 import { OperationTemplate } from '@calc/positional-calculator';
-import {
-    AlgorithmType,
-    MultiplicationType,
-    OperationType,
-} from '@calc/calc-arithmetic';
+import { AlgorithmType, MultiplicationType, OperationType } from '@calc/calc-arithmetic';
 import {
     getCellByCoords,
     getMultiplicationResult,
@@ -38,15 +34,9 @@ describe('BoothMcSorley Multiplication', () => {
         getOperationGrid().toMatchSnapshot();
 
         // should display proper popover for addition rows
-        getCellByCoords(13, 11)
-            .trigger('mouseover')
-            .getByDataTest('add-at-position')
-            .contains('S_{0}=0');
+        getCellByCoords(13, 11).trigger('mouseover').getByDataTest('add-at-position').contains('S_{0}=0');
 
-        getCellByCoords(3, 11)
-            .trigger('mouseover')
-            .getByDataTest('add-at-position')
-            .contains('S_{10}=1');
+        getCellByCoords(3, 11).trigger('mouseover').getByDataTest('add-at-position').contains('S_{10}=1');
 
         gridHasProperResultRow(expectedComplement, base, 13, 11);
         gridHasProperSdRow(expectedSD, 13, 3);
@@ -66,17 +56,11 @@ describe('BoothMcSorley Multiplication', () => {
         getMultiplicationResult().toMatchSnapshot();
         getOperationGrid().toMatchSnapshot();
 
-        getCellByCoords(13, 3)
-            .trigger('mouseover')
-            .getByDataTest('sd-by-0-details');
+        getCellByCoords(13, 3).trigger('mouseover').getByDataTest('sd-by-0-details');
 
-        getCellByCoords(10, 3)
-            .trigger('mouseover')
-            .getByDataTest('sd-by-1-details');
+        getCellByCoords(10, 3).trigger('mouseover').getByDataTest('sd-by-1-details');
 
-        getCellByCoords(7, 3)
-            .trigger('mouseover')
-            .getByDataTest('sd-by--1-details');
+        getCellByCoords(7, 3).trigger('mouseover').getByDataTest('sd-by--1-details');
     });
 
     it('should multiply two U2 numbers with positive multiplier', () => {
@@ -96,15 +80,9 @@ describe('BoothMcSorley Multiplication', () => {
         getMultiplicationResult().toMatchSnapshot();
         getOperationGrid().toMatchSnapshot();
 
-        getCellByCoords(11, 10)
-            .trigger('mouseover')
-            .getByDataTest('add-at-position')
-            .contains('S_{0}=0');
+        getCellByCoords(11, 10).trigger('mouseover').getByDataTest('add-at-position').contains('S_{0}=0');
 
-        getCellByCoords(4, 10)
-            .trigger('mouseover')
-            .getByDataTest('add-at-position')
-            .contains('S_{7}=1');
+        getCellByCoords(4, 10).trigger('mouseover').getByDataTest('add-at-position').contains('S_{7}=1');
 
         gridHasProperResultRow(expectedComplement, base, 11, 10);
         gridHasProperSdRow(expectedSD, 11, 3);
@@ -148,5 +126,20 @@ describe('BoothMcSorley Multiplication', () => {
         getOperationGrid().toMatchSnapshot();
 
         gridHasProperResultRow(expectedComplement, base, 21, 15);
+    });
+
+    it('should display proper SD groups on SD multiplier digit hover', () => {
+        const base = 2;
+        const config: OperationTemplate<AlgorithmType> = {
+            operands: ['(0)1101001.101', '(1)1101.111'],
+            operation: OperationType.Multiplication,
+            algorithm: MultiplicationType.BoothMcSorley,
+            base,
+        };
+        const expected = '-11100000.011101';
+        const expectedSD = '0,0,0,0,0,-1,1,0,0,0,-1';
+
+        operationReturnsProperResult(config, expected);
+        gridHasProperSdRow(expectedSD, 21, 3);
     });
 });

--- a/apps/calc-web-e2e/src/support/positional-calculator.ts
+++ b/apps/calc-web-e2e/src/support/positional-calculator.ts
@@ -17,9 +17,7 @@ export const getOperandListInput = (index: number) => {
 
 export const addOperand = (representation: string, index = 0) => {
     getAddOperandButton().click();
-    getOperandListInput(index)
-        .clear()
-        .type(representation);
+    getOperandListInput(index).clear().type(representation);
 };
 
 export const addOperands = (operands: string[]) => {
@@ -49,7 +47,6 @@ export const getMultiplicationResult = () => cy.getByDataTest('multiplication-re
 export const getOperationGrid = () => cy.get('#operation-grid');
 export const getOperationGridSaveButton = () => cy.getByDataTest('operation-grid-save');
 
-
 export const calculatePositional = (config: OperationTemplate<AlgorithmType>) => {
     const { algorithm, base, operands, operation } = config;
     setOperationBase(base);
@@ -59,25 +56,25 @@ export const calculatePositional = (config: OperationTemplate<AlgorithmType>) =>
     getCalculateButton().click();
 };
 
-
 export const operationReturnsProperResult = (config: OperationTemplate<AlgorithmType>, result: string) => {
     calculatePositional(config);
     hasProperResult(result);
     hasSuccessNotification();
 };
 
-export const gridHasProperResultRow = (representation: string, base: number, bottomRightX: number, bottomRightY: number) => {
-    const stripped = representation
-        .replace('.', '')
-        .replace('(', '')
-        .replace(')', '');
+export const gridHasProperResultRow = (
+    representation: string,
+    base: number,
+    bottomRightX: number,
+    bottomRightY: number
+) => {
+    const stripped = representation.replace('.', '').replace('(', '').replace(')', '');
 
     const asDigits = splitToDigitsList(stripped, base);
     const positionsAscending = asDigits.reverse();
 
     positionsAscending.forEach((d, index) => {
-        getCellByCoords(bottomRightX - index, bottomRightY)
-            .contains(d.representationInBase);
+        getCellByCoords(bottomRightX - index, bottomRightY).contains(d.representationInBase);
     });
 };
 
@@ -86,12 +83,12 @@ export const gridHasProperSdRow = (representation: string, sdRowEndX: number, sd
 
     sdDigits.forEach((d, index) => {
         getCellByCoords(sdRowEndX - index, sdRowEndY)
-            .contains(d);
+            .contains(d)
+            .trigger('mouseover')
+            .getByDataTest(`sd-by-${d}-details`);
     });
 };
-
 
 export const getCellByCoords = (x: number, y: number) => {
     return cy.getByDataTest(`operation-grid-${x}-${y}`);
 };
-

--- a/libs/calc-arithmetic/src/lib/positional/signed-digit/booth-converter.ts
+++ b/libs/calc-arithmetic/src/lib/positional/signed-digit/booth-converter.ts
@@ -4,19 +4,18 @@ import {
     SDConversionResult,
     SDGroupDigit,
     SignedDigitConversionType,
-    SignedDigitConverter
+    SignedDigitConverter,
 } from './signed-digit-converter';
 import { flatten } from 'lodash';
-import { Digit } from '../../models';
 import { BaseDigits } from '../base-digits';
 import { positionRangeSlice } from '../digits';
 import { findPositionRange } from '../operation-utils';
 
 export class BoothConverter implements SignedDigitConverter {
-    protected readonly digits: Digit[];
+    protected readonly digits: SDGroupDigit[];
     protected readonly isNegative: boolean;
 
-    constructor(digits: Digit[], negative = false) {
+    constructor(digits: SDGroupDigit[], negative = false) {
         this.digits = digits;
         this.isNegative = negative;
     }
@@ -49,26 +48,24 @@ export class BoothConverter implements SignedDigitConverter {
         };
     }
 
-    private extractOutputFromGroups(groups: SDConversionGroupResult[]) {
+    private extractOutputFromGroups(groups: SDConversionGroupResult[]): SDGroupDigit[] {
         const output: SDGroupDigit[] = flatten(groups.map((g) => g.output));
         const { lsp, msp } = findPositionRange([this.digits]);
         return positionRangeSlice(output, lsp, msp);
     }
 
-    protected extend(digits: Digit[]): SDGroupDigit[] {
+    protected extend(digits: SDGroupDigit[]): SDGroupDigit[] {
         const lastPosition = digits[digits.length - 1].position;
         const extension: SDGroupDigit = {
-            ...BaseDigits.getDigit(0, 2, lastPosition - 1),
             isPaddingDigit: true,
+            ...BaseDigits.getDigit(0, 2, lastPosition - 1),
         };
         return [...digits, extension];
     }
 
     protected splitToGroups(digits: SDGroupDigit[]): SDGroupDigit[][] {
         const groups: SDGroupDigit[][] = [];
-        walkOverlaping(digits, this.groupSize, this.overlapSize, (group) =>
-            groups.push(group)
-        );
+        walkOverlaping(digits, this.groupSize, this.overlapSize, (group) => groups.push(group));
         return groups;
     }
 
@@ -89,7 +86,7 @@ export class BoothConverter implements SignedDigitConverter {
         // |value| =  prev  -  curr
         const [x1, x0] = input;
         const value = x0.valueInDecimal - x1.valueInDecimal;
-        const output: Digit[] = [
+        const output: SDGroupDigit[] = [
             {
                 base: 2,
                 valueInDecimal: value,

--- a/libs/calc-arithmetic/src/lib/positional/signed-digit/booth-mcsorley-converter.ts
+++ b/libs/calc-arithmetic/src/lib/positional/signed-digit/booth-mcsorley-converter.ts
@@ -1,9 +1,5 @@
 import { BoothConverter } from './booth-converter';
-import { Digit } from '../../models';
-import {
-    SDConversionGroupResult,
-    SDGroupDigit, SignedDigitConversionType
-} from './signed-digit-converter';
+import { SDConversionGroupResult, SDGroupDigit, SignedDigitConversionType } from './signed-digit-converter';
 import { BaseDigits } from '../base-digits';
 import { leastSignificantPosition } from '../digits';
 
@@ -16,49 +12,48 @@ export class BoothMcSorleyConverter extends BoothConverter {
         return SignedDigitConversionType.BoothMcSorley;
     }
 
-    protected extend(): Digit[] {
+    protected extend(): SDGroupDigit[] {
         const extendFraction = this.extendFraction(this.digits);
         return this.extendIntegerPart(extendFraction);
     }
 
-    protected extendFraction(digits: Digit[]): Digit[] {
+    protected extendFraction(digits: SDGroupDigit[]): SDGroupDigit[] {
         const lsp = leastSignificantPosition(digits);
         const extensionCount = lsp % 2 === 0 ? 1 : 2;
-        if(extensionCount === 1) {
+        if (extensionCount === 1) {
             const extension: SDGroupDigit = {
-                ...BaseDigits.getDigit(0, 2, lsp -1),
                 isPaddingDigit: true,
+                ...BaseDigits.getDigit(0, 2, lsp - 1),
             };
-            return [...digits, extension]
+            return [...digits, extension];
         } else {
             const extension: SDGroupDigit = {
-                ...BaseDigits.getDigit(0, 2, lsp -1),
                 isPaddingDigit: true,
+                ...BaseDigits.getDigit(0, 2, lsp - 1),
             };
             const extension2: SDGroupDigit = {
-                ...BaseDigits.getDigit(0, 2, lsp -2),
                 isPaddingDigit: true,
+                ...BaseDigits.getDigit(0, 2, lsp - 2),
             };
-            return [...digits, extension, extension2]
+            return [...digits, extension, extension2];
         }
     }
 
-    protected extendIntegerPart(digits: Digit[]): Digit[] {
+    protected extendIntegerPart(digits: SDGroupDigit[]): SDGroupDigit[] {
         const mspDigit = digits[0];
         const shouldExtendFront = mspDigit.position % 2 === 0;
         if (!shouldExtendFront) return digits;
         const extension: SDGroupDigit = {
-            ...BaseDigits.getDigit(this.isNegative ? 1 : 0, 2, mspDigit.position + 1),
             isPaddingDigit: true,
+            ...BaseDigits.getDigit(this.isNegative ? 1 : 0, 2, mspDigit.position + 1),
         };
 
-        return [extension, ...digits]
+        return [extension, ...digits];
     }
 
     protected createSdDigit(input: SDGroupDigit[]): SDConversionGroupResult {
         const [x2, x1, x0] = input;
-        const value =
-            -2 * x2.valueInDecimal + x1.valueInDecimal + x0.valueInDecimal;
+        const value = -2 * x2.valueInDecimal + x1.valueInDecimal + x0.valueInDecimal;
         const [currValue, prevValue] = this.splitToPositionValues(value);
 
         const currDigit: SDGroupDigit = {
@@ -66,7 +61,7 @@ export class BoothMcSorleyConverter extends BoothConverter {
             valueInDecimal: currValue,
             representationInBase: currValue.toString(),
             position: x2.position,
-            isPaddingDigit: x2.isPaddingDigit
+            isPaddingDigit: x2.isPaddingDigit,
         };
 
         const prevDigit: SDGroupDigit = {
@@ -74,8 +69,8 @@ export class BoothMcSorleyConverter extends BoothConverter {
             valueInDecimal: prevValue,
             representationInBase: prevValue.toString(),
             position: x1.position,
+            isPaddingDigit: x1.isPaddingDigit,
         };
-
 
         return { input, output: [currDigit, prevDigit], value };
     }

--- a/libs/calc-arithmetic/src/lib/positional/signed-digit/signed-digit-converter.ts
+++ b/libs/calc-arithmetic/src/lib/positional/signed-digit/signed-digit-converter.ts
@@ -1,7 +1,7 @@
 import { Digit } from '../../models';
 
 export interface SignedDigitConverter {
-    toSignedDigits(): Digit[];
+    toSignedDigits(): SDGroupDigit[];
     toSignedDigitsWithDetails(): SDConversionResult;
 }
 

--- a/libs/positional-calculator/src/lib/multiplication/multiplication-grid/builders/booth-mc-sorley-builder.tsx
+++ b/libs/positional-calculator/src/lib/multiplication/multiplication-grid/builders/booth-mc-sorley-builder.tsx
@@ -11,56 +11,16 @@ export class BoothMcSorleyBuilder extends BoothBuilder {
         index: number,
         outputIndex: number
     ): CellGroup {
+        const evenNumOfFractionDigits = Math.max(this.info.maxOperandsFractionDigits) % 2 === 0;
 
-        if(output.isPaddingDigit) {
-            return {
-                cells: []
-            }
+        if (evenNumOfFractionDigits) {
+            return this.buildGroupForEven(group, output, index, outputIndex);
+        } else {
+            return this.buildGroupForOdd(group, output, index, outputIndex);
         }
-        const rowCellsThatAreMultiplied = this.getCellsToAdd(output);
-        const { totalWidth } = this.info;
-        const yOffset = this.getMultiplierRowStartOffset();
-        const groupOffset = 2 * index + 1;
-
-        const isPartialOutputGroup = group.output.length === 1;
-
-
-        const trigger1: CellConfig = {
-            x: totalWidth - groupOffset,
-            y: 1 + yOffset,
-            preventGroupTrigger: outputIndex === 0 && !isPartialOutputGroup
-        };
-
-        const trigger2: CellConfig = {
-            x: totalWidth - groupOffset - 1,
-            y: 1 + yOffset,
-            preventGroupTrigger: outputIndex === 1 && !isPartialOutputGroup
-        };
-
-        const rowOffset = isPartialOutputGroup ? 0 : outputIndex === 0 ? 1 : 0;
-        const rowIndex = 2* index + rowOffset;
-        const resultRow = this.buildMultiplyByDigitResultRow(rowIndex);
-        const sdGroupCells = this.getMultiplierSDGroupCells(trigger1, group);
-
-        return {
-            cells: [
-                ...rowCellsThatAreMultiplied,
-                ...resultRow,
-                ...sdGroupCells,
-                trigger1,
-                trigger2,
-            ],
-            contentProps: {},
-            popoverPlacement: index === 0 ? 'right' : 'left',
-            anchorPosition: index === 0 ? trigger1 : trigger2,
-            contentBuilder: () => <BoothMcSorleyGroupResult result={group} outputIndex={outputIndex} />,
-        };
     }
 
-    protected getMultiplierSDGroupCells(
-        trigger: CellConfig,
-        group: SDConversionGroupResult
-    ): CellConfig[] {
+    protected getMultiplierSDGroupCells(trigger: CellConfig, group: SDConversionGroupResult): CellConfig[] {
         const groupStart: CellConfig = {
             x: trigger.x - 1,
             y: trigger.y - 1,
@@ -71,5 +31,86 @@ export class BoothMcSorleyBuilder extends BoothBuilder {
         };
 
         return groupCellsInStraightLine(groupStart, groupEnd, true);
+    }
+
+    private buildGroupForOdd(
+        group: SDConversionGroupResult,
+        output: SDGroupDigit,
+        index: number,
+        outputIndex: number
+    ): CellGroup {
+        if (output.isPaddingDigit) {
+            return {
+                cells: [],
+            };
+        }
+
+        const { totalWidth } = this.info;
+        const yOffset = this.getMultiplierRowStartOffset();
+        const groupOffset = 2 * index;
+
+        const trigger1: CellConfig = {
+            x: totalWidth - groupOffset,
+            y: 1 + yOffset,
+            preventGroupTrigger: index === 0 ? false : outputIndex === 0,
+        };
+
+        const trigger2: CellConfig = {
+            x: totalWidth - groupOffset - 1,
+            y: 1 + yOffset,
+            preventGroupTrigger: index === 0 ? false : outputIndex === 1,
+        };
+
+        const rowIndex = index === 0 ? 0 : 2 * index - outputIndex;
+        const resultRow = this.buildMultiplyByDigitResultRow(rowIndex);
+        const rowCellsThatAreMultiplied = this.getCellsToAdd(output);
+        const sdGroupCells = this.getMultiplierSDGroupCells(trigger1, group);
+
+        return {
+            cells: [...rowCellsThatAreMultiplied, ...resultRow, ...sdGroupCells, trigger1, trigger2],
+            contentProps: {},
+            popoverPlacement: index === 0 ? 'right' : 'left',
+            anchorPosition: trigger2,
+            contentBuilder: () => <BoothMcSorleyGroupResult result={group} outputIndex={outputIndex} />,
+        };
+    }
+
+    private buildGroupForEven(
+        group: SDConversionGroupResult,
+        output: SDGroupDigit,
+        index: number,
+        outputIndex: number
+    ): CellGroup {
+        const rowCellsThatAreMultiplied = this.getCellsToAdd(output);
+        const { totalWidth } = this.info;
+        const yOffset = this.getMultiplierRowStartOffset();
+        const groupOffset = 2 * index + 1;
+
+        const isPartialOutputGroup = group.output.length === 1;
+
+        const trigger1: CellConfig = {
+            x: totalWidth - groupOffset,
+            y: 1 + yOffset,
+            preventGroupTrigger: outputIndex === 0 && !isPartialOutputGroup,
+        };
+
+        const trigger2: CellConfig = {
+            x: totalWidth - groupOffset - 1,
+            y: 1 + yOffset,
+            preventGroupTrigger: outputIndex === 1 && !isPartialOutputGroup,
+        };
+
+        const rowOffset = isPartialOutputGroup ? 0 : outputIndex === 0 ? 1 : 0;
+        const rowIndex = 2 * index + rowOffset;
+        const resultRow = this.buildMultiplyByDigitResultRow(rowIndex);
+        const sdGroupCells = this.getMultiplierSDGroupCells(trigger1, group);
+
+        return {
+            cells: [...rowCellsThatAreMultiplied, ...resultRow, ...sdGroupCells, trigger1, trigger2],
+            contentProps: {},
+            popoverPlacement: index === 0 ? 'right' : 'left',
+            anchorPosition: index === 0 ? trigger1 : trigger2,
+            contentBuilder: () => <BoothMcSorleyGroupResult result={group} outputIndex={outputIndex} />,
+        };
     }
 }

--- a/libs/positional-calculator/src/lib/multiplication/sd-group-result/booth-mc-sorley-group-result.tsx
+++ b/libs/positional-calculator/src/lib/multiplication/sd-group-result/booth-mc-sorley-group-result.tsx
@@ -23,7 +23,6 @@ export const BoothMcSorleyGroupResult: FC<P> = ({ result, outputIndex }) => {
           + ${x0.valueInDecimal}
           = ${result.value}`;
 
-
     const digitSplitResult = `${result.value} \\mapsto
       SD_${curr?.position} = ${curr?.valueInDecimal},
       SD_${prev?.position} = ${prev?.valueInDecimal}`;


### PR DESCRIPTION
- RC: for cases when number of multipier fractions digits
  was even, various indices for group cells and placements
  were incorrect
- fix: extract the even/odd branches to separate methods
  and fix indices (fugly)

closes #167 