### PR TITLE
Fix grid for 1/100 #185

### DIFF
--- a/apps/calc-web-e2e/__snapshots__/index.js.snap
+++ b/apps/calc-web-e2e/__snapshots__/index.js.snap
@@ -51853,9 +51853,7 @@ exports[`Default Division > should divide two positive numbers with integer divi
     <div
       data-test="operation-grid-2-4"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    >
-      0
-    </div>
+    ></div>
     <div
       data-test="operation-grid-3-4"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
@@ -52351,9 +52349,7 @@ exports[`Default Division > should divide two integer numbers with fraction divi
     <div
       data-test="operation-grid-2-4"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    >
-      0
-    </div>
+    ></div>
     <div
       data-test="operation-grid-3-4"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
@@ -53206,9 +53202,7 @@ exports[`Default Division > should divide integer number by divisor with fractio
     <div
       data-test="operation-grid-3-4"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    >
-      0
-    </div>
+    ></div>
     <div
       data-test="operation-grid-4-4"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
@@ -53297,9 +53291,7 @@ exports[`Default Division > should divide integer number by divisor with fractio
     <div
       data-test="operation-grid-4-6"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    >
-      0
-    </div>
+    ></div>
     <div
       data-test="operation-grid-5-6"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
@@ -54107,9 +54099,7 @@ exports[`Default Division > should divide two numbers with fraction part #1`] = 
     <div
       data-test="operation-grid-3-4"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    >
-      0
-    </div>
+    ></div>
     <div
       data-test="operation-grid-4-4"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
@@ -54198,9 +54188,7 @@ exports[`Default Division > should divide two numbers with fraction part #1`] = 
     <div
       data-test="operation-grid-4-6"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    >
-      0
-    </div>
+    ></div>
     <div
       data-test="operation-grid-5-6"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
@@ -54383,9 +54371,7 @@ exports[`Default Division > should divide two numbers with fraction part #1`] = 
     <div
       data-test="operation-grid-6-10"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    >
-      0
-    </div>
+    ></div>
     <div
       data-test="operation-grid-7-10"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
@@ -56715,9 +56701,7 @@ exports[`Default Division > should divide positive and negative numbers #1`] = `
     <div
       data-test="operation-grid-2-4"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    >
-      0
-    </div>
+    ></div>
     <div
       data-test="operation-grid-3-4"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
@@ -57044,7 +57028,9 @@ exports[`Default Division > should divide smaller dividend with fraction part by
     <div
       data-test="operation-grid-1-0"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    ></div>
+    >
+      0
+    </div>
     <div
       data-test="operation-grid-2-0"
       class="makeStyles-defaultCellWithVerticalAndHorizontalLine-109 makeStyles-horizontalLine-106"
@@ -57144,26 +57130,20 @@ exports[`Default Division > should divide smaller dividend with fraction part by
       data-test="operation-grid-1-2"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
     >
-      1
+      0
     </div>
     <div
       data-test="operation-grid-2-2"
-      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    >
-      1
-    </div>
+      class="makeStyles-defaultCell-100"
+    ></div>
     <div
       data-test="operation-grid-3-2"
-      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    >
-      5
-    </div>
+      class="makeStyles-defaultCell-100"
+    ></div>
     <div
       data-test="operation-grid-4-2"
-      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    >
-      5
-    </div>
+      class="makeStyles-defaultCell-100"
+    ></div>
     <div
       data-test="operation-grid-5-2"
       class="makeStyles-defaultCell-100"
@@ -57194,23 +57174,24 @@ exports[`Default Division > should divide smaller dividend with fraction part by
       data-test="operation-grid-0-3"
       class="makeStyles-defaultCell-100"
     ></div>
-    <div
-      data-test="operation-grid-1-3"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div
-      data-test="operation-grid-2-3"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div data-test="operation-grid-3-3" class="makeStyles-defaultCell-100">
-      2
-    </div>
-    <div data-test="operation-grid-4-3" class="makeStyles-defaultCell-100">
+    <div data-test="operation-grid-1-3" class="makeStyles-defaultCell-100">
       1
     </div>
-    <div data-test="operation-grid-5-3" class="makeStyles-defaultCell-100">
-      6
+    <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-100">
+      1
     </div>
+    <div
+      data-test="operation-grid-3-3"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-4-3"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-5-3"
+      class="makeStyles-defaultCell-100"
+    ></div>
     <div
       data-test="operation-grid-6-3"
       class="makeStyles-defaultCell-100"
@@ -57235,34 +57216,32 @@ exports[`Default Division > should divide smaller dividend with fraction part by
   <div class="makeStyles-gridRow-92">
     <div
       data-test="operation-grid-0-4"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div
-      data-test="operation-grid-1-4"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div
-      data-test="operation-grid-2-4"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
     >
       -
     </div>
     <div
-      data-test="operation-grid-3-4"
+      data-test="operation-grid-1-4"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
     ></div>
     <div
-      data-test="operation-grid-4-4"
+      data-test="operation-grid-2-4"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
     >
       0
     </div>
     <div
+      data-test="operation-grid-3-4"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-4-4"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
       data-test="operation-grid-5-4"
-      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    >
-      0
-    </div>
+      class="makeStyles-defaultCell-100"
+    ></div>
     <div
       data-test="operation-grid-6-4"
       class="makeStyles-defaultCell-100"
@@ -57289,26 +57268,27 @@ exports[`Default Division > should divide smaller dividend with fraction part by
       data-test="operation-grid-0-5"
       class="makeStyles-defaultCell-100"
     ></div>
-    <div
-      data-test="operation-grid-1-5"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div
-      data-test="operation-grid-2-5"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div data-test="operation-grid-3-5" class="makeStyles-defaultCell-100">
-      2
-    </div>
-    <div data-test="operation-grid-4-5" class="makeStyles-defaultCell-100">
+    <div data-test="operation-grid-1-5" class="makeStyles-defaultCell-100">
       1
     </div>
-    <div data-test="operation-grid-5-5" class="makeStyles-defaultCell-100">
-      6
+    <div data-test="operation-grid-2-5" class="makeStyles-defaultCell-100">
+      1
     </div>
-    <div data-test="operation-grid-6-5" class="makeStyles-defaultCell-100">
-      2
+    <div data-test="operation-grid-3-5" class="makeStyles-defaultCell-100">
+      7
     </div>
+    <div
+      data-test="operation-grid-4-5"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-5-5"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-6-5"
+      class="makeStyles-defaultCell-100"
+    ></div>
     <div
       data-test="operation-grid-7-5"
       class="makeStyles-defaultCell-100"
@@ -57329,42 +57309,36 @@ exports[`Default Division > should divide smaller dividend with fraction part by
   <div class="makeStyles-gridRow-92">
     <div
       data-test="operation-grid-0-6"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div
-      data-test="operation-grid-1-6"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div
-      data-test="operation-grid-2-6"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
     >
       -
     </div>
     <div
-      data-test="operation-grid-3-6"
+      data-test="operation-grid-1-6"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    >
-      2
-    </div>
+    ></div>
     <div
-      data-test="operation-grid-4-6"
+      data-test="operation-grid-2-6"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    ></div>
+    <div
+      data-test="operation-grid-3-6"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
     >
       0
     </div>
     <div
+      data-test="operation-grid-4-6"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
       data-test="operation-grid-5-6"
-      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    >
-      7
-    </div>
+      class="makeStyles-defaultCell-100"
+    ></div>
     <div
       data-test="operation-grid-6-6"
-      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    >
-      9
-    </div>
+      class="makeStyles-defaultCell-100"
+    ></div>
     <div
       data-test="operation-grid-7-6"
       class="makeStyles-defaultCell-100"
@@ -57387,31 +57361,30 @@ exports[`Default Division > should divide smaller dividend with fraction part by
       data-test="operation-grid-0-7"
       class="makeStyles-defaultCell-100"
     ></div>
-    <div
-      data-test="operation-grid-1-7"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div
-      data-test="operation-grid-2-7"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div
-      data-test="operation-grid-3-7"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div
-      data-test="operation-grid-4-7"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div data-test="operation-grid-5-7" class="makeStyles-defaultCell-100">
-      8
+    <div data-test="operation-grid-1-7" class="makeStyles-defaultCell-100">
+      1
     </div>
-    <div data-test="operation-grid-6-7" class="makeStyles-defaultCell-100">
-      3
+    <div data-test="operation-grid-2-7" class="makeStyles-defaultCell-100">
+      1
     </div>
-    <div data-test="operation-grid-7-7" class="makeStyles-defaultCell-100">
-      0
+    <div data-test="operation-grid-3-7" class="makeStyles-defaultCell-100">
+      7
     </div>
+    <div data-test="operation-grid-4-7" class="makeStyles-defaultCell-100">
+      6
+    </div>
+    <div
+      data-test="operation-grid-5-7"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-6-7"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-7-7"
+      class="makeStyles-defaultCell-100"
+    ></div>
     <div
       data-test="operation-grid-8-7"
       class="makeStyles-defaultCell-100"
@@ -57428,44 +57401,46 @@ exports[`Default Division > should divide smaller dividend with fraction part by
   <div class="makeStyles-gridRow-92">
     <div
       data-test="operation-grid-0-8"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div
-      data-test="operation-grid-1-8"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div
-      data-test="operation-grid-2-8"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div
-      data-test="operation-grid-3-8"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div
-      data-test="operation-grid-4-8"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
     >
       -
     </div>
     <div
-      data-test="operation-grid-5-8"
+      data-test="operation-grid-1-8"
       class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
     >
-      6
+      1
     </div>
+    <div
+      data-test="operation-grid-2-8"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      1
+    </div>
+    <div
+      data-test="operation-grid-3-8"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      5
+    </div>
+    <div
+      data-test="operation-grid-4-8"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      5
+    </div>
+    <div
+      data-test="operation-grid-5-8"
+      class="makeStyles-defaultCell-100"
+    ></div>
     <div
       data-test="operation-grid-6-8"
-      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    >
-      9
-    </div>
+      class="makeStyles-defaultCell-100"
+    ></div>
     <div
       data-test="operation-grid-7-8"
-      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
-    >
-      3
-    </div>
+      class="makeStyles-defaultCell-100"
+    ></div>
     <div
       data-test="operation-grid-8-8"
       class="makeStyles-defaultCell-100"
@@ -57492,23 +57467,23 @@ exports[`Default Division > should divide smaller dividend with fraction part by
       data-test="operation-grid-2-9"
       class="makeStyles-defaultCell-100"
     ></div>
-    <div
-      data-test="operation-grid-3-9"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div
-      data-test="operation-grid-4-9"
-      class="makeStyles-defaultCell-100"
-    ></div>
-    <div data-test="operation-grid-5-9" class="makeStyles-defaultCell-100">
+    <div data-test="operation-grid-3-9" class="makeStyles-defaultCell-100">
+      2
+    </div>
+    <div data-test="operation-grid-4-9" class="makeStyles-defaultCell-100">
       1
     </div>
-    <div data-test="operation-grid-6-9" class="makeStyles-defaultCell-100">
-      3
+    <div data-test="operation-grid-5-9" class="makeStyles-defaultCell-100">
+      6
     </div>
-    <div data-test="operation-grid-7-9" class="makeStyles-defaultCell-100">
-      7
-    </div>
+    <div
+      data-test="operation-grid-6-9"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-7-9"
+      class="makeStyles-defaultCell-100"
+    ></div>
     <div
       data-test="operation-grid-8-9"
       class="makeStyles-defaultCell-100"
@@ -57519,6 +57494,294 @@ exports[`Default Division > should divide smaller dividend with fraction part by
     ></div>
     <div
       data-test="operation-grid-10-9"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-10"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-1-10"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-2-10"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      -
+    </div>
+    <div
+      data-test="operation-grid-3-10"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    ></div>
+    <div
+      data-test="operation-grid-4-10"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    ></div>
+    <div
+      data-test="operation-grid-5-10"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-6-10"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-7-10"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-8-10"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-9-10"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-10-10"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-11"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-1-11"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-2-11"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div data-test="operation-grid-3-11" class="makeStyles-defaultCell-100">
+      2
+    </div>
+    <div data-test="operation-grid-4-11" class="makeStyles-defaultCell-100">
+      1
+    </div>
+    <div data-test="operation-grid-5-11" class="makeStyles-defaultCell-100">
+      6
+    </div>
+    <div data-test="operation-grid-6-11" class="makeStyles-defaultCell-100">
+      2
+    </div>
+    <div
+      data-test="operation-grid-7-11"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-8-11"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-9-11"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-10-11"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-12"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-1-12"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-2-12"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      -
+    </div>
+    <div
+      data-test="operation-grid-3-12"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      2
+    </div>
+    <div
+      data-test="operation-grid-4-12"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-5-12"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      7
+    </div>
+    <div
+      data-test="operation-grid-6-12"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      9
+    </div>
+    <div
+      data-test="operation-grid-7-12"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-8-12"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-9-12"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-10-12"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-13"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-1-13"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-2-13"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-3-13"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-4-13"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div data-test="operation-grid-5-13" class="makeStyles-defaultCell-100">
+      8
+    </div>
+    <div data-test="operation-grid-6-13" class="makeStyles-defaultCell-100">
+      3
+    </div>
+    <div data-test="operation-grid-7-13" class="makeStyles-defaultCell-100">
+      0
+    </div>
+    <div
+      data-test="operation-grid-8-13"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-9-13"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-10-13"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-14"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-1-14"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-2-14"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-3-14"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-4-14"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      -
+    </div>
+    <div
+      data-test="operation-grid-5-14"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      6
+    </div>
+    <div
+      data-test="operation-grid-6-14"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      9
+    </div>
+    <div
+      data-test="operation-grid-7-14"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      3
+    </div>
+    <div
+      data-test="operation-grid-8-14"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-9-14"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-10-14"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-15"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-1-15"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-2-15"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-3-15"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-4-15"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div data-test="operation-grid-5-15" class="makeStyles-defaultCell-100">
+      1
+    </div>
+    <div data-test="operation-grid-6-15" class="makeStyles-defaultCell-100">
+      3
+    </div>
+    <div data-test="operation-grid-7-15" class="makeStyles-defaultCell-100">
+      7
+    </div>
+    <div
+      data-test="operation-grid-8-15"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-9-15"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-10-15"
       class="makeStyles-defaultCell-100"
     ></div>
   </div>
@@ -57703,6 +57966,736 @@ exports[`Default Division > should divide 1.1/100 #0`] = `
                         ><span></span></span></span></span></span></span></span></span></span
       ></span>
     </div>
+  </div>
+</div>
+`;
+
+exports[`Default Division > should divide 1.1/100 #1`] = `
+<div class="makeStyles-cellContent-95" id="operation-grid">
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-0"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-1-0"
+      class="makeStyles-defaultCellWithVerticalAndHorizontalLine-109 makeStyles-horizontalLine-106"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-2-0"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-3-0"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      1
+    </div>
+    <div
+      data-test="operation-grid-4-0"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      1
+    </div>
+    <div
+      data-test="operation-grid-5-0"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    ></div>
+    <div
+      data-test="operation-grid-6-0"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-1"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-1-1"
+      class="makeStyles-defaultCellWithVerticalLine-108"
+    >
+      1
+    </div>
+    <div data-test="operation-grid-2-1" class="makeStyles-defaultCell-100">
+      1
+    </div>
+    <div data-test="operation-grid-3-1" class="makeStyles-defaultCell-100">
+      :
+    </div>
+    <div data-test="operation-grid-4-1" class="makeStyles-defaultCell-100">
+      1
+    </div>
+    <div data-test="operation-grid-5-1" class="makeStyles-defaultCell-100">
+      0
+    </div>
+    <div data-test="operation-grid-6-1" class="makeStyles-defaultCell-100">
+      0
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-2"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      -
+    </div>
+    <div
+      data-test="operation-grid-1-2"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-2-2"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-3-2"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-4-2"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-5-2"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-6-2"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-3"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div data-test="operation-grid-1-3" class="makeStyles-defaultCell-100">
+      1
+    </div>
+    <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-100">
+      1
+    </div>
+    <div
+      data-test="operation-grid-3-3"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-4-3"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-5-3"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-6-3"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-4"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      -
+    </div>
+    <div
+      data-test="operation-grid-1-4"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    ></div>
+    <div
+      data-test="operation-grid-2-4"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-3-4"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-4-4"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-5-4"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-6-4"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-5"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div data-test="operation-grid-1-5" class="makeStyles-defaultCell-100">
+      1
+    </div>
+    <div data-test="operation-grid-2-5" class="makeStyles-defaultCell-100">
+      1
+    </div>
+    <div data-test="operation-grid-3-5" class="makeStyles-defaultCell-100">
+      0
+    </div>
+    <div
+      data-test="operation-grid-4-5"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-5-5"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-6-5"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-6"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      -
+    </div>
+    <div
+      data-test="operation-grid-1-6"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      1
+    </div>
+    <div
+      data-test="operation-grid-2-6"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-3-6"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-4-6"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-5-6"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-6-6"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-7"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-1-7"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div data-test="operation-grid-2-7" class="makeStyles-defaultCell-100">
+      1
+    </div>
+    <div data-test="operation-grid-3-7" class="makeStyles-defaultCell-100">
+      0
+    </div>
+    <div data-test="operation-grid-4-7" class="makeStyles-defaultCell-100">
+      0
+    </div>
+    <div
+      data-test="operation-grid-5-7"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-6-7"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-8"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-1-8"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      -
+    </div>
+    <div
+      data-test="operation-grid-2-8"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      1
+    </div>
+    <div
+      data-test="operation-grid-3-8"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-4-8"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-5-8"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-6-8"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-9"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-1-9"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-2-9"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-3-9"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div data-test="operation-grid-4-9" class="makeStyles-defaultCell-100">
+      0
+    </div>
+    <div
+      data-test="operation-grid-5-9"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-6-9"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+</div>
+`;
+
+exports[`Default Division > should divide 1/100 #0`] = `
+<div data-test="division-result" data-result="0.01">
+  <div class="makeStyles-row-88">
+    <div class="makeStyles-operand-89">
+      <span
+        ><span class="katex"
+          ><span class="katex-mathml"
+            ><math xmlns="http://www.w3.org/1998/Math/MathML"
+              ><semantics
+                ><mrow
+                  ><msub><mn>1</mn><mn>10</mn></msub></mrow
+                ><annotation encoding="application/x-tex"
+                  >1_{10}</annotation
+                ></semantics
+              ></math
+            ></span
+          ><span class="katex-html" aria-hidden="true"
+            ><span class="base"
+              ><span
+                class="strut"
+                style="height:0.79444em;vertical-align:-0.15em;"
+              ></span
+              ><span class="mord"
+                ><span class="mord">1</span
+                ><span class="msupsub"
+                  ><span class="vlist-t vlist-t2"
+                    ><span class="vlist-r"
+                      ><span class="vlist" style="height:0.30110799999999993em;"
+                        ><span
+                          style="top:-2.5500000000000003em;margin-left:0em;margin-right:0.05em;"
+                          ><span class="pstrut" style="height:2.7em;"></span
+                          ><span class="sizing reset-size6 size3 mtight"
+                            ><span class="mord mtight"
+                              ><span class="mord mtight">1</span
+                              ><span class="mord mtight">0</span></span
+                            ></span
+                          ></span
+                        ></span
+                      ><span class="vlist-s">​</span></span
+                    ><span class="vlist-r"
+                      ><span class="vlist" style="height:0.15em;"
+                        ><span></span></span></span></span></span></span></span></span></span
+      ></span>
+    </div>
+    <div class="makeStyles-symbol-90">
+      <span
+        ><span class="katex"
+          ><span class="katex-mathml"
+            ><math xmlns="http://www.w3.org/1998/Math/MathML"
+              ><semantics
+                ><mrow><mi mathvariant="normal">/</mi></mrow
+                ><annotation encoding="application/x-tex"
+                  >/</annotation
+                ></semantics
+              ></math
+            ></span
+          ><span class="katex-html" aria-hidden="true"
+            ><span class="base"
+              ><span
+                class="strut"
+                style="height:1em;vertical-align:-0.25em;"
+              ></span
+              ><span class="mord">/</span></span
+            ></span
+          ></span
+        ></span
+      >
+    </div>
+    <div class="makeStyles-operand-89">
+      <span
+        ><span class="katex"
+          ><span class="katex-mathml"
+            ><math xmlns="http://www.w3.org/1998/Math/MathML"
+              ><semantics
+                ><mrow
+                  ><mn>10</mn><msub><mn>0</mn><mn>10</mn></msub></mrow
+                ><annotation encoding="application/x-tex"
+                  >100_{10}</annotation
+                ></semantics
+              ></math
+            ></span
+          ><span class="katex-html" aria-hidden="true"
+            ><span class="base"
+              ><span
+                class="strut"
+                style="height:0.79444em;vertical-align:-0.15em;"
+              ></span
+              ><span class="mord">1</span><span class="mord">0</span
+              ><span class="mord"
+                ><span class="mord">0</span
+                ><span class="msupsub"
+                  ><span class="vlist-t vlist-t2"
+                    ><span class="vlist-r"
+                      ><span class="vlist" style="height:0.30110799999999993em;"
+                        ><span
+                          style="top:-2.5500000000000003em;margin-left:0em;margin-right:0.05em;"
+                          ><span class="pstrut" style="height:2.7em;"></span
+                          ><span class="sizing reset-size6 size3 mtight"
+                            ><span class="mord mtight"
+                              ><span class="mord mtight">1</span
+                              ><span class="mord mtight">0</span></span
+                            ></span
+                          ></span
+                        ></span
+                      ><span class="vlist-s">​</span></span
+                    ><span class="vlist-r"
+                      ><span class="vlist" style="height:0.15em;"
+                        ><span></span></span></span></span></span></span></span></span></span
+      ></span>
+    </div>
+    <div class="makeStyles-symbol-90">
+      <span
+        ><span class="katex"
+          ><span class="katex-mathml"
+            ><math xmlns="http://www.w3.org/1998/Math/MathML"
+              ><semantics
+                ><mrow><mo>=</mo></mrow
+                ><annotation encoding="application/x-tex"
+                  >=</annotation
+                ></semantics
+              ></math
+            ></span
+          ><span class="katex-html" aria-hidden="true"
+            ><span class="base"
+              ><span
+                class="strut"
+                style="height:0.36687em;vertical-align:0em;"
+              ></span
+              ><span class="mrel">=</span></span
+            ></span
+          ></span
+        ></span
+      >
+    </div>
+    <div class="makeStyles-operand-89">
+      <span
+        ><span class="katex"
+          ><span class="katex-mathml"
+            ><math xmlns="http://www.w3.org/1998/Math/MathML"
+              ><semantics
+                ><mrow
+                  ><mn>0.0</mn><msub><mn>1</mn><mn>10</mn></msub></mrow
+                ><annotation encoding="application/x-tex"
+                  >0.01_{10}</annotation
+                ></semantics
+              ></math
+            ></span
+          ><span class="katex-html" aria-hidden="true"
+            ><span class="base"
+              ><span
+                class="strut"
+                style="height:0.79444em;vertical-align:-0.15em;"
+              ></span
+              ><span class="mord">0</span><span class="mord">.</span
+              ><span class="mord">0</span
+              ><span class="mord"
+                ><span class="mord">1</span
+                ><span class="msupsub"
+                  ><span class="vlist-t vlist-t2"
+                    ><span class="vlist-r"
+                      ><span class="vlist" style="height:0.30110799999999993em;"
+                        ><span
+                          style="top:-2.5500000000000003em;margin-left:0em;margin-right:0.05em;"
+                          ><span class="pstrut" style="height:2.7em;"></span
+                          ><span class="sizing reset-size6 size3 mtight"
+                            ><span class="mord mtight"
+                              ><span class="mord mtight">1</span
+                              ><span class="mord mtight">0</span></span
+                            ></span
+                          ></span
+                        ></span
+                      ><span class="vlist-s">​</span></span
+                    ><span class="vlist-r"
+                      ><span class="vlist" style="height:0.15em;"
+                        ><span></span></span></span></span></span></span></span></span></span
+      ></span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Default Division > should divide 1/100 #1`] = `
+<div class="makeStyles-cellContent-95" id="operation-grid">
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-0"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-1-0"
+      class="makeStyles-defaultCellWithVerticalAndHorizontalLine-109 makeStyles-horizontalLine-106"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-2-0"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-3-0"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      1
+    </div>
+    <div
+      data-test="operation-grid-4-0"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    ></div>
+    <div
+      data-test="operation-grid-5-0"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-1"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div data-test="operation-grid-1-1" class="makeStyles-defaultCell-100">
+      1
+    </div>
+    <div data-test="operation-grid-2-1" class="makeStyles-defaultCell-100">
+      :
+    </div>
+    <div data-test="operation-grid-3-1" class="makeStyles-defaultCell-100">
+      1
+    </div>
+    <div data-test="operation-grid-4-1" class="makeStyles-defaultCell-100">
+      0
+    </div>
+    <div data-test="operation-grid-5-1" class="makeStyles-defaultCell-100">
+      0
+    </div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-2"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      -
+    </div>
+    <div
+      data-test="operation-grid-1-2"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-2-2"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-3-2"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-4-2"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-5-2"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-3"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div data-test="operation-grid-1-3" class="makeStyles-defaultCell-100">
+      1
+    </div>
+    <div data-test="operation-grid-2-3" class="makeStyles-defaultCell-100">
+      0
+    </div>
+    <div
+      data-test="operation-grid-3-3"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-4-3"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-5-3"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-4"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      -
+    </div>
+    <div
+      data-test="operation-grid-1-4"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    ></div>
+    <div
+      data-test="operation-grid-2-4"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-3-4"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-4-4"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-5-4"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-5"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div data-test="operation-grid-1-5" class="makeStyles-defaultCell-100">
+      1
+    </div>
+    <div data-test="operation-grid-2-5" class="makeStyles-defaultCell-100">
+      0
+    </div>
+    <div data-test="operation-grid-3-5" class="makeStyles-defaultCell-100">
+      0
+    </div>
+    <div
+      data-test="operation-grid-4-5"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-5-5"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-6"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      -
+    </div>
+    <div
+      data-test="operation-grid-1-6"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      1
+    </div>
+    <div
+      data-test="operation-grid-2-6"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-3-6"
+      class="makeStyles-defaultCell-100 makeStyles-horizontalLine-106"
+    >
+      0
+    </div>
+    <div
+      data-test="operation-grid-4-6"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-5-6"
+      class="makeStyles-defaultCell-100"
+    ></div>
+  </div>
+  <div class="makeStyles-gridRow-92">
+    <div
+      data-test="operation-grid-0-7"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-1-7"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-2-7"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div data-test="operation-grid-3-7" class="makeStyles-defaultCell-100">
+      0
+    </div>
+    <div
+      data-test="operation-grid-4-7"
+      class="makeStyles-defaultCell-100"
+    ></div>
+    <div
+      data-test="operation-grid-5-7"
+      class="makeStyles-defaultCell-100"
+    ></div>
   </div>
 </div>
 `;

--- a/apps/calc-web-e2e/src/integration/positional/division/default-division.spec.ts
+++ b/apps/calc-web-e2e/src/integration/positional/division/default-division.spec.ts
@@ -189,5 +189,22 @@ describe('Default Division', () => {
 
         operationReturnsProperResult(config, expected);
         getDivisionResult().toMatchSnapshot();
+        getOperationGrid().toMatchSnapshot();
+    });
+
+    // BUG #185
+    it('should divide 1/100', () => {
+        const base = 10;
+        const config: OperationTemplate<AlgorithmType> = {
+            operands: ['1', '100'],
+            operation: OperationType.Division,
+            algorithm: MultiplicationType.Default,
+            base
+        };
+        const expected = '0.01';
+
+        operationReturnsProperResult(config, expected);
+        getDivisionResult().toMatchSnapshot();
+        getOperationGrid().toMatchSnapshot();
     });
 });

--- a/libs/calc-arithmetic/src/lib/positional/division/division.spec.ts
+++ b/libs/calc-arithmetic/src/lib/positional/division/division.spec.ts
@@ -74,7 +74,7 @@ describe('#division', () => {
         });
 
 
-        it('should return proper slice for initial division when slice should have more digits than divisor', () => {
+        it('should return proper slice for initial division when slice should have more digits than divisor and divisor is greater than dividend', () => {
             // given
             const base = 10;
             const dividend = fromStringDirect('0.76621', base).result;
@@ -83,8 +83,8 @@ describe('#division', () => {
             const { slice, sliceSourceLsp } = getDividendSlice(dividend.toDigitsList(), divisor.toDigitsList());
 
             // then
-            const expectedStr = '7662';
-            const expectedLsp = -4;
+            const expectedStr = '0';
+            const expectedLsp = 0;
             expect(slice.toString()).toEqual(expectedStr);
             expect(sliceSourceLsp).toEqual(expectedLsp);
         });
@@ -597,7 +597,7 @@ describe('#division', () => {
             const result = divideDefault([dividend, divisor]);
 
             // then
-            const expected = '0.000625';
+            const expected = '0.00062';
             expect(result.numberResult.toString()).toEqual(expected);
         });
 

--- a/libs/calc-arithmetic/src/lib/positional/division/division.ts
+++ b/libs/calc-arithmetic/src/lib/positional/division/division.ts
@@ -68,7 +68,7 @@ export function divideDigits(dividend: DivisionOperand[], divisor: DivisionOpera
     }
 
     const resultDigits = positionResultsToNumber(positionResults);
-    const numberResult = fromDigits(resultDigits).result;
+    const numberResult = fromDigits(trimLeadingZeros(resultDigits)).result;
 
     return {
         numberOperands: [],
@@ -192,6 +192,9 @@ function getInitialDividendSlice(dividend: DivisionOperand[], divisor: DivisionO
 }
 
 function initialSliceLength(dividend: DivisionOperand[], divisor: DivisionOperand[]): number {
+    const dividendAsNum = fromDigits(dividend).result.toNumber();
+    const divisorNum = fromDigits(divisor).result.toNumber();
+    if(divisorNum > dividendAsNum) return 1;
     const numDivisorDigits = divisor.length;
     const sliceAsNum = fromDigits(dividend.slice(0, numDivisorDigits)).result.toNumber();
     const divisorAsNum = fromDigits(divisor).result.toNumber();

--- a/libs/positional-calculator/src/lib/division/division-grid/division-grid.spec.tsx
+++ b/libs/positional-calculator/src/lib/division/division-grid/division-grid.spec.tsx
@@ -74,7 +74,7 @@ describe('division-grid', () => {
             const meta = extractDivisionResultMeta(result);
 
             // then
-            const expected = 1;
+            const expected = 0;
             expect(meta.resultRowLeftOffset).toEqual(expected);
         });
 

--- a/libs/positional-calculator/src/lib/division/division-grid/division-grid.tsx
+++ b/libs/positional-calculator/src/lib/division/division-grid/division-grid.tsx
@@ -94,7 +94,10 @@ function getGridLines(result: DivisionResult): GridLine[] {
     let prevTo: number | undefined = undefined;
     result.stepResults.forEach((step, idx) => {
         const [minuend, subtrahend] = step.subtractionResult.numberOperands;
-        const maxOpDigits = Math.max(minuend.numDigits(), subtrahend.numDigits());
+        const subtrahendDigits = subtrahend.toNumber() === 0
+            ? subtrahend.asDigits().slice(0, 1)
+            : subtrahend.asDigits();
+        const maxOpDigits = Math.max(minuend.numDigits(), subtrahendDigits.length);
         const lineLength = maxOpDigits + 1;
         const lineFrom = prevTo
             ? prevTo - maxOpDigits + 1
@@ -152,17 +155,21 @@ function buildDefaultSubtractionRows(step: DivisionPositionResult, totalWidth: n
     const { divisionIndex } = step;
     const [minuend, subtrahend] = step.subtractionResult.numberOperands;
     const minuendDigits = minuend.asDigits();
-    const subtrahendDigits = subtrahend.asDigits();
+    const subtrahendDigits = subtrahend.toNumber() === 0
+        ? subtrahend.asDigits().slice(0, 1)
+        : subtrahend.asDigits();
 
     const leftPaddingLength = prevMaxIndex ?
         prevMaxIndex - minuendDigits.length + 2
         : divisionIndex + 1;
+
 
     const minuendRow = padWithEmptyCells(
         digitsToCellConfig(minuendDigits),
         minuendDigits.length + leftPaddingLength,
         'Left'
     );
+
 
     const subtrahendRow = padWithEmptyCells(
         digitsToCellConfig(subtrahendDigits),
@@ -184,7 +191,9 @@ function buildDefaultSubtractionRows(step: DivisionPositionResult, totalWidth: n
 function buildInitialSubtractionRow(step: DivisionPositionResult, totalWidth: number, numSteps: number): SubtractionRowCells {
     const subtractionRows: GridCellConfig[][] = [];
     const [minuend, subtrahend] = step.subtractionResult.numberOperands;
-    const subtrahendDigits = subtrahend.asDigits();
+    const subtrahendDigits = subtrahend.toNumber() === 0
+        ? subtrahend.asDigits().slice(0, 1)
+        : subtrahend.asDigits();
     const minuendDigits = minuend.asDigits();
     const leftPaddingLength = 1;
     const desiredWidth = Math.max(subtrahendDigits.length, minuendDigits.length) + leftPaddingLength;
@@ -265,6 +274,7 @@ function buildOperationRow(result: DivisionResult, totalWidth: number): GridCell
         ...digitsToCellConfig(divisor)
     ];
 
+
     const leftPadded = padWithEmptyCells(
         operationDigitsCells,
         operationDigitsCells.length + leftOffset,
@@ -299,13 +309,10 @@ export function extractDivisionResultMeta(result: DivisionResult): DivisionResul
     const numResultDigits = result.numberResult.numDigits();
 
     const [scaledDividend, scaledDivisor] = result.operands;
-    const dividendLsp = dividend.leastSignificantPosition();
-    const resultLsp = result.numberResult.leastSignificantPosition();
-    const positionDiff = dividendLsp - resultLsp;
     const numOperandsDigits = scaledDividend.length + scaledDivisor.length;
     const resultRowLeftOffset = Math.abs(dividend.toNumber()) >= Math.abs(divisor.toNumber())
         ? Math.abs(scaledDividend.length - baseMeta.numResultIntegerPartDigits)
-        : positionDiff;
+        : 0;
 
     const spaceForFirstMinusSign = 1;
     const resultRowLength = spaceForFirstMinusSign + resultRowLeftOffset + numResultDigits;


### PR DESCRIPTION
- change the length of initial slice, for cases when
  abs(dividend) < abs(divisor) always take one digit
  at a time, for other cases, take as many digits as
  it takes to make slice that is greater than divisor
- RC: wrong slice generation and zeros having 2 digits
  in subtraction rows instead of one
- Fix: when subtrahend is 0, display it in one cell

closes #185 