### PR TITLE
Division by 0 still possible #190

### DIFF
--- a/apps/calc-web-e2e/src/integration/positional/division/default-division.spec.ts
+++ b/apps/calc-web-e2e/src/integration/positional/division/default-division.spec.ts
@@ -1,11 +1,11 @@
 import { OperationTemplate } from '@calc/positional-calculator';
 import { AlgorithmType, MultiplicationType, OperationType } from '@calc/calc-arithmetic';
 import {
-    enterOperation, getCalculateButton,
+    enterOperationParams, getCalculateButton,
     getDivisionResult,
     getOperationGrid,
     gridHasProperResultRow,
-    operationReturnsProperResult
+    operationReturnsProperResult, selectOperation
 } from '../../../support/positional-calculator';
 
 describe('Default Division', () => {
@@ -224,7 +224,7 @@ describe('Default Division', () => {
         getOperationGrid().toMatchSnapshot();
     });
 
-    it.only('should prevent division by 0', () => {
+    it('should prevent division by 0', () => {
         const base = 10;
         const config: OperationTemplate<AlgorithmType> = {
             operands: ['100', '0'],
@@ -233,7 +233,21 @@ describe('Default Division', () => {
             base
         };
 
-        enterOperation(config);
+        enterOperationParams(config);
+        getCalculateButton().should('be.disabled');
+        cy.get('.MuiFormHelperText-root').contains('Cannot divide by 0');
+    });
+
+    it('should prevent division by 0 when operation changes to division and divisor would be 0', () => {
+        const base = 10;
+        const config: OperationTemplate<AlgorithmType> = {
+            operands: ['100', '0'],
+            operation: OperationType.Multiplication,
+            algorithm: MultiplicationType.Default,
+            base
+        };
+        enterOperationParams(config);
+        selectOperation(OperationType.Division);
         getCalculateButton().should('be.disabled');
         cy.get('.MuiFormHelperText-root').contains('Cannot divide by 0');
     });

--- a/apps/calc-web-e2e/src/support/positional-calculator.ts
+++ b/apps/calc-web-e2e/src/support/positional-calculator.ts
@@ -49,11 +49,11 @@ export const getOperationGrid = () => cy.get('#operation-grid');
 export const getOperationGridSaveButton = () => cy.getByDataTest('operation-grid-save');
 
 export const calculatePositional = (config: OperationTemplate<AlgorithmType>) => {
-    enterOperation(config);
+    enterOperationParams(config);
     getCalculateButton().click();
 };
 
-export const enterOperation = (config: OperationTemplate<AlgorithmType>) => {
+export const enterOperationParams = (config: OperationTemplate<AlgorithmType>) => {
     const { algorithm, base, operands, operation } = config;
     setOperationBase(base);
     selectAlgorithm(algorithm);

--- a/libs/positional-calculator/src/lib/operand-input/operand-input.tsx
+++ b/libs/positional-calculator/src/lib/operand-input/operand-input.tsx
@@ -21,7 +21,7 @@ interface P extends ListItemProps {
 }
 
 
-export const OperandInput: FC<P> = ({ representationStr, onRepresentationChange, base, index, onRemove, dataTest, numOperands, validators = [], ...rest }) => {
+export const OperandInput: FC<P> = ({ representationStr, onRepresentationChange, base, index, onRemove, dataTest, numOperands, validators, ...rest }) => {
     const { t } = useTranslation();
     const [representation, setRepresentation] = useState(representationStr);
     const [error, setError] = useState<string | undefined>();
@@ -35,7 +35,7 @@ export const OperandInput: FC<P> = ({ representationStr, onRepresentationChange,
             index,
             totalNumOperands: numOperands
         };
-        const err = validateOperand([...baseValidators, ...validators], input);
+        const err = validateOperand([...baseValidators, ...(validators || [])], input);
 
         if (err) {
             const { key, options } = err;
@@ -43,6 +43,7 @@ export const OperandInput: FC<P> = ({ representationStr, onRepresentationChange,
         } else {
             setError(undefined);
         }
+
         onRepresentationChange(representation, index, !err);
         // WARNING: adding all deps here MAY cause infinite loop in
         // tests for components that use this component, so if the
@@ -51,7 +52,7 @@ export const OperandInput: FC<P> = ({ representationStr, onRepresentationChange,
         // may be an anonymous function, and those cannot be compared
         // The deps will be added by automatically by lint--fix,
         // so use it with caution
-    }, [base, representation, index]);
+    }, [base, representation, index, validators]);
 
 
     return (

--- a/libs/positional-calculator/src/lib/operand-list/operand-list.tsx
+++ b/libs/positional-calculator/src/lib/operand-list/operand-list.tsx
@@ -84,6 +84,7 @@ export const OperandList: FC<P> = ({ inputBase, operands, onChange, onAdd, canAd
         onChange(newOperands);
     };
 
+
     const items = operands.map((item, index) => {
         return (
             <Draggable key={item.dndKey} draggableId={`${item.dndKey}`} index={index}>

--- a/libs/positional-calculator/src/lib/validators/validators.ts
+++ b/libs/positional-calculator/src/lib/validators/validators.ts
@@ -7,7 +7,7 @@ import {
 } from '@calc/calc-arithmetic';
 
 
-export const isDivisorZero: OperandValidator = (input) => {
+export function isDivisorZero(input: OperandInputValue): TranslationErrorMessage | undefined {
     const { totalNumOperands, index, representation, base } = input;
     if (totalNumOperands !== 2) return undefined;
     if (index !== 1) return undefined;
@@ -19,9 +19,9 @@ export const isDivisorZero: OperandValidator = (input) => {
             };
         }
     }
-};
+}
 
-export const representationValidator: OperandValidator = (input: OperandInputValue) => {
+export function representationValidator(input: OperandInputValue): TranslationErrorMessage | undefined {
     const { representation, base } = input;
     if (!isValidComplementOrRepresentationStr(representation, base)) {
         return {
@@ -29,7 +29,7 @@ export const representationValidator: OperandValidator = (input: OperandInputVal
             options: { base }
         };
     }
-};
+}
 
 export function validateOperand(validators: OperandValidator[], input: OperandInputValue): TranslationErrorMessage | undefined {
     for (const validator of validators) {


### PR DESCRIPTION
- RC: the operand validators for algorithm were
  not added to deps of representation change useEffect
  in operand input
- Fix: add validators to deps. WARNING: the default empty
  array for 'validators' prop was removed, because it
  caused inifite useEffect loop (similiar comparision
  issue as for arrow funcs)
  
  closes #190 