### PR TITLE
Fix forward ref issue in failed sanity check #200

### DIFF
--- a/libs/positional-calculator/src/lib/positional-calculator-view/positional-calculator-view.tsx
+++ b/libs/positional-calculator/src/lib/positional-calculator-view/positional-calculator-view.tsx
@@ -163,7 +163,9 @@ export const PositionalCalculatorView: FC = () => {
                     anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
                     open={errorOpen}
                 >
-                    <SanityCheckFailed onClose={handleErrorClose} expected={expected} actual={actual}/>
+                    <Alert severity="error" onClose={handleErrorClose}>
+                        <SanityCheckFailed expected={expected} actual={actual}/>
+                    </Alert>
                 </Snackbar>
                 <Snackbar
                     anchorOrigin={{ vertical: 'top', horizontal: 'right' }}

--- a/libs/positional-calculator/src/lib/sanity-check/sanity-check-failed.tsx
+++ b/libs/positional-calculator/src/lib/sanity-check/sanity-check-failed.tsx
@@ -1,29 +1,25 @@
-import { Alert } from '@mui/material';
 import React, {FC} from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface P {
     expected: string;
     actual: string;
-    onClose: () => void;
 }
 
-export const SanityCheckFailed: FC<P> = ({expected, actual, onClose}) => {
+export const SanityCheckFailed: FC<P> = ({expected, actual}) => {
     const {t} = useTranslation();
 
     return (
-        <Alert onClose={onClose} severity="error">
-            <div data-test="sanity-check-failed">
-                <div>
-                    {t('positionalCalculator.sanityCheck')}
-                </div>
-                <div>
-                    {t('positionalCalculator.expected', {expected})}
-                </div>
-                <div>
-                    {t('positionalCalculator.actual', {actual})}
-                </div>
+        <div data-test="sanity-check-failed">
+            <div>
+                {t('positionalCalculator.sanityCheck')}
             </div>
-        </Alert>
+            <div>
+                {t('positionalCalculator.expected', {expected})}
+            </div>
+            <div>
+                {t('positionalCalculator.actual', {actual})}
+            </div>
+        </div>
     )
 };


### PR DESCRIPTION
- RC: after move to react 17 and mui v5, function
  components used as children need to have forwarded
  ref - and in tis case, snackbar/alert for failed
  sanity check did not have it
- Fix: move mui alret component outside of SanityCheckFailed

closes #200 