### PR TITLE
Failed multiplication #219

### DIFF
--- a/libs/calc-arithmetic/src/lib/positional/complement-extension.ts
+++ b/libs/calc-arithmetic/src/lib/positional/complement-extension.ts
@@ -96,9 +96,9 @@ export function extendComplement<T extends Digit>(digits: T[], numPositions: num
 
 
 export function mergeComplementExtension<T extends Digit>(resultDigits: T[], positionResults: PositionResult<T>[]): AdditionOperand[] {
+    if(!canMerge(resultDigits)) return resultDigits;
     const [, extensionDigit, ...rest] = resultDigits;
     let startPositionIndex = mergedComplementStartIndex(resultDigits);
-
     const positionIndexBeforeStart = startPositionIndex - 1;
 
     const shouldStartFromPreviousPosition = startPositionIndex >= 1
@@ -111,6 +111,16 @@ export function mergeComplementExtension<T extends Digit>(resultDigits: T[], pos
     const nonExtensionDigits = rest.slice(startPositionIndex);
 
     return [mergedExtension, ...nonExtensionDigits];
+}
+
+function canMerge<T extends Digit>(resultDigits: T[]): boolean {
+    const [, secondDigit] = resultDigits;
+    return canBeExtensionDigit(secondDigit);
+}
+
+function canBeExtensionDigit<T extends Digit>(digit: T): boolean {
+    return digit.valueInDecimal === 0 || digit.valueInDecimal === digit.base - 1;
+
 }
 
 function mergedComplementStartIndex<T extends Digit>(resultDigits: T[]): number {
@@ -127,7 +137,7 @@ function mergedComplementStartIndex<T extends Digit>(resultDigits: T[]): number 
 }
 
 
-function prevPositionGeneratedFromInitialDigits<T extends Digit>(index: number, digits: AdditionOperand[], positionResults: PositionResult<T>[]): boolean {
+function prevPositionGeneratedFromInitialDigits<T extends Digit>(index: number, digits: T[], positionResults: PositionResult<T>[]): boolean {
     const prevPosition = digits[index - 1].position;
     const prevPositionResult = positionResults.find((res) => res.valueAtPosition.position === prevPosition);
 

--- a/libs/calc-arithmetic/src/lib/positional/multiplication/with-extension.spec.ts
+++ b/libs/calc-arithmetic/src/lib/positional/multiplication/with-extension.spec.ts
@@ -189,5 +189,56 @@ describe('multiply-with-extensions', () => {
             expect(result.numberResult.toString()).toEqual(expected);
             expect(result.numberResult.complement.toString()).toEqual(expectedComplement);
         });
+
+        // BUG #219
+        it('should multiply 2 base 7 numbers', () => {
+            // given
+            const base = 7;
+            const x = fromStringDirect('4', base).result;
+            const y = fromStringDirect('3', base).result;
+
+            // when
+            const result = multiplyWithExtensions([x, y]);
+
+            // then
+            const expected = '15';
+            const expectedComplement = '(0)15';
+            expect(result.numberResult.toString()).toEqual(expected);
+            expect(result.numberResult.complement.toString()).toEqual(expectedComplement);
+        });
+
+        // BUG #219
+        it('should multiply 2 base 11 numbers', () => {
+            // given
+            const base = 11;
+            const x = fromStringDirect('5', base).result;
+            const y = fromStringDirect('94', base).result;
+
+            // when
+            const result = multiplyWithExtensions([x, y]);
+
+            // then
+            const expected = '429';
+            const expectedComplement = '(0)429';
+            expect(result.numberResult.toString()).toEqual(expected);
+            expect(result.numberResult.complement.toString()).toEqual(expectedComplement);
+        });
+
+        // BUG #219
+        it('should multiply 2 base 4 numbers', () => {
+            // given
+            const base = 4;
+            const x = fromStringDirect('2', base).result;
+            const y = fromStringDirect('3300', base).result;
+
+            // when
+            const result = multiplyWithExtensions([x, y]);
+
+            // then
+            const expected = '13200';
+            const expectedComplement = '(0)13200';
+            expect(result.numberResult.toString()).toEqual(expected);
+            expect(result.numberResult.complement.toString()).toEqual(expectedComplement);
+        });
     });
 });

--- a/libs/calc-arithmetic/src/lib/positional/multiplication/without-extension.spec.ts
+++ b/libs/calc-arithmetic/src/lib/positional/multiplication/without-extension.spec.ts
@@ -55,6 +55,57 @@ describe('multiplication-without-extension', () => {
             expect(result.numberResult.complement.toString()).toEqual(expectedComplement);
         });
 
+        // BUG #219
+        it('should multiply 2 base 7 numbers', () => {
+            // given
+            const base = 7;
+            const x = fromStringDirect('4', base).result;
+            const y = fromStringDirect('3', base).result;
+
+            // when
+            const result = multiplyWithoutExtension([x, y]);
+
+            // then
+            const expected = '15';
+            const expectedComplement = '(0)15';
+            expect(result.numberResult.toString()).toEqual(expected);
+            expect(result.numberResult.complement.toString()).toEqual(expectedComplement);
+        });
+
+        // BUG #219
+        it('should multiply 2 base 11 numbers', () => {
+            // given
+            const base = 11;
+            const x = fromStringDirect('5', base).result;
+            const y = fromStringDirect('94', base).result;
+
+            // when
+            const result = multiplyWithoutExtension([x, y]);
+
+            // then
+            const expected = '429';
+            const expectedComplement = '(0)429';
+            expect(result.numberResult.toString()).toEqual(expected);
+            expect(result.numberResult.complement.toString()).toEqual(expectedComplement);
+        });
+
+        // BUG #219
+        it('should multiply 2 base 4 numbers', () => {
+            // given
+            const base = 4;
+            const x = fromStringDirect('2', base).result;
+            const y = fromStringDirect('3300', base).result;
+
+            // when
+            const result = multiplyWithoutExtension([x, y]);
+
+            // then
+            const expected = '13200';
+            const expectedComplement = '(0)13200';
+            expect(result.numberResult.toString()).toEqual(expected);
+            expect(result.numberResult.complement.toString()).toEqual(expectedComplement);
+        });
+
         it('should multiply positive U2 numbers by negative', () => {
             // given
             const base = 8;

--- a/libs/positional-calculator/src/lib/core/sanity-check.spec.ts
+++ b/libs/positional-calculator/src/lib/core/sanity-check.spec.ts
@@ -101,7 +101,7 @@ describe('sanity-check', () => {
 
         itIf(χάος)('should survive multiplication with extension', () => {
             // given
-            const reps = 1000;
+            const reps = 10000;
 
             // when
             const result = kaosMonke(OperationType.Multiplication, MultiplicationType.WithExtension, reps);


### PR DESCRIPTION
- RC: another merge extension error, digits with
  only one extension digit like (0)15 were
  merged improperly to (6)5
- Fix: check if digits can be merged (second digit must
  be an extension digit) and if not, return initial digits
  
  closes #219 