### PR TITLE
Sanity check failed for binary division #222

### DIFF
--- a/libs/positional-calculator/src/lib/core/sanity-check.spec.ts
+++ b/libs/positional-calculator/src/lib/core/sanity-check.spec.ts
@@ -39,6 +39,28 @@ describe('sanity-check', () => {
             expect(result.failed).toEqual(expected);
         });
 
+        it('should return proper check for binary operation that has correct binary result but wrong decimal (due to float precision loss_ v2', () => {
+            // given
+            const base = 2;
+            const params: OperationParams = {
+                operands: [
+                    fromStringDirect('0.1', base).result,
+                    fromStringDirect('11010.01', base).result
+                ],
+                algorithm: DivisionType.Default,
+                operation: OperationType.Division,
+                base
+            };
+            const operationResult = calculate(params).result;
+
+            // when
+            const result = sanityCheck(params, operationResult);
+
+            // then
+            const expected = false;
+            expect(result.failed).toEqual(expected);
+        });
+
         it('should return proper check for decimal operation that has correct representation but wrong decimal (due to float precision loss', () => {
             // -7.9049999999999999 != -7.905
             // given
@@ -61,7 +83,6 @@ describe('sanity-check', () => {
             const expected = false;
             expect(result.failed).toEqual(expected);
         });
-
 
     });
 

--- a/libs/positional-calculator/src/lib/core/sanity-check.ts
+++ b/libs/positional-calculator/src/lib/core/sanity-check.ts
@@ -110,7 +110,7 @@ export function sanityCheck(params: OperationParams, actual: PositionalNumber): 
     const precision = 2;
     const fixedExpected = expectedDecimal.toFixed(precision);
     const fixedActual = actual.decimalValue.toFixed(precision);
-    const differenceToBig = expectedDecimal.minus(actual.decimalValue).abs().isGreaterThan(0.01);
+    const differenceToBig = expectedDecimal.minus(actual.decimalValue).abs().isGreaterThan(0.1);
     const fixedDecimalDifferent = !(fixedExpected === fixedActual);
 
     let failed = fixedDecimalDifferent && differenceToBig;


### PR DESCRIPTION
- RC: precision loss, division was made to 5 digits, and
  the actual result started to have non-zero results after
  the 5th fraction digit
- Fix: reduce the check precision to +/- 0.1 in decimal
  Reasoning for that is when algorithm has implementation
  error and operation fails it almost always returns result
  that differs more than 0.1. When difference is lesser
  then 0.1 it usually indicates some kind of precision/floating
  fuckery. That way actual implementation errors are detected
  and false negatives for sanity check are reduced
  
  closes #222 