### PR TITLE
Result row shifted #194

### DIFF
--- a/libs/calc-arithmetic/src/lib/positional/division/division.ts
+++ b/libs/calc-arithmetic/src/lib/positional/division/division.ts
@@ -36,7 +36,7 @@ function prepareDivisionOperands(dividend: PositionalNumber, divisor: Positional
             dividend.toDigitsList(),
             divisor.toDigitsList()
         ],
-        [OperandsTransformType.ScaleToDivisor]
+        [OperandsTransformType.TrimExcessZeros, OperandsTransformType.ScaleToDivisor]
     );
 }
 

--- a/libs/positional-calculator/src/lib/division/division-grid/division-grid.spec.tsx
+++ b/libs/positional-calculator/src/lib/division/division-grid/division-grid.spec.tsx
@@ -92,5 +92,21 @@ describe('division-grid', () => {
             const expected = 0;
             expect(meta.resultRowLeftOffset).toEqual(expected);
         });
+
+        // BUG #194
+        it('should return proper left offset for division by 1 when dividend has fraction part', () => {
+            // given
+            const base = 10;
+            const dividend = fromStringDirect('1230.99903', base).result;
+            const divisor = fromStringDirect('1', base).result;
+            const result = divideDefault([dividend, divisor]);
+
+            // when
+            const meta = extractDivisionResultMeta(result);
+
+            // then
+            const expected = 0;
+            expect(meta.resultRowLeftOffset).toEqual(expected);
+        });
     });
 });

--- a/libs/positional-calculator/src/lib/division/division-grid/division-grid.tsx
+++ b/libs/positional-calculator/src/lib/division/division-grid/division-grid.tsx
@@ -2,7 +2,7 @@ import {
     digitsToStr,
     DivisionOperand,
     DivisionPositionResult,
-    DivisionResult,
+    DivisionResult, fromDigits,
     leastSignificantPosition
 } from '@calc/calc-arithmetic';
 import {
@@ -308,9 +308,7 @@ export function extractDivisionResultMeta(result: DivisionResult): DivisionResul
 
     const [scaledDividend, scaledDivisor] = result.operands;
     const numOperandsDigits = scaledDividend.length + scaledDivisor.length;
-    const resultRowLeftOffset = Math.abs(dividend.toNumber()) >= Math.abs(divisor.toNumber())
-        ? Math.abs(scaledDividend.length - baseMeta.numResultIntegerPartDigits)
-        : 0;
+    const resultRowLeftOffset = getResultRowLeftOffset(result);
 
     const spaceForFirstMinusSign = 1;
     const resultRowLength = spaceForFirstMinusSign + resultRowLeftOffset + numResultDigits;
@@ -329,4 +327,18 @@ export function extractDivisionResultMeta(result: DivisionResult): DivisionResul
         numResultDigits,
         resultRowLeftOffset
     };
+}
+
+function getResultRowLeftOffset(result: DivisionResult): number {
+    const [dividend, divisor] = result.numberOperands;
+    const [scaledDividend, scaledDivisor] = result.operands;
+    const baseMeta = extractResultMeta(result);
+
+    const isDivisionByOne = fromDigits(scaledDivisor).result.toNumber() === 1;
+    if(isDivisionByOne) return 0;
+
+    const dividendGreater = Math.abs(dividend.toNumber()) >= Math.abs(divisor.toNumber());
+    if(!dividendGreater) return 0;
+
+    return Math.abs(scaledDividend.length - baseMeta.numResultIntegerPartDigits);
 }


### PR DESCRIPTION
- RC: row shifted due to wrong resultRowLeftOffset in meta
- Fix: not sure if this is the right choice, but condition
  was added that checks for division by 1, and returns 0
  offset if it happens. Could not find general solution
  that would handle this case. Fortunately it's quite a rare
  case - everybody knows division by 1 result
  
  closes #194 