### PR TITLE
Invalid characters allowed in bconv input #181

### DIFF
--- a/apps/calc-web-e2e/src/integration/positional/base-conversion.spec.ts
+++ b/apps/calc-web-e2e/src/integration/positional/base-conversion.spec.ts
@@ -20,7 +20,7 @@ describe('Base converter error labels', () => {
     });
 
     it('should display error when input base is invalid and disable convert button', () => {
-        const errorText = 'Base must be between 2 and 99';
+        const errorText = 'Base must be an integer between 2 and 99';
         const labelId = '#inputBase-helper-text';
 
         getInputBaseInput().type('1');
@@ -36,7 +36,7 @@ describe('Base converter error labels', () => {
     });
 
     it('should display error when output base is invalid and disable convert button', () => {
-        const errorText = 'Base must be between 2 and 99';
+        const errorText = 'Base must be an integer between 2 and 99';
         const labelId = '#outputBase-helper-text';
         getOutputBaseInput().clear().type('1');
         cy.get(labelId).contains(errorText);
@@ -63,7 +63,7 @@ describe('Base converter error labels', () => {
 
     // BUG #180
     it('should display proper validation errors after bases are swapped', () => {
-        const errorText = 'Base must be between 2 and 99';
+        const errorText = 'Base must be an integer between 2 and 99';
         const inputBaseErrorLabelId = '#inputBase-helper-text';
         const outputBaseErrorLabelId = '#outputBase-helper-text';
 
@@ -85,6 +85,27 @@ describe('Base converter error labels', () => {
         cy.get(outputBaseErrorLabelId).contains(errorText);
         cy.get(inputBaseErrorLabelId).should('not.exist');
         getBconvConvertButton().should('be.disabled');
+    });
+
+    // BUG #181
+    it('should display base validation error when base is not an integer', () => {
+        const errorText = 'Base must be an integer between 2 and 99';
+        const inputBaseErrorLabelId = '#inputBase-helper-text';
+        const outputBaseErrorLabelId = '#outputBase-helper-text';
+
+        // Base is a number but not a integer
+        getInputBaseInput().clear().type('10.2');
+        getOutputBaseInput().clear().type('2.4');
+        cy.get(inputBaseErrorLabelId).contains(errorText);
+        cy.get(outputBaseErrorLabelId).contains(errorText);
+    });
+
+    // BUG #181
+    it('should prevent letters being typed into input/output base inputs', () => {
+        getInputBaseInput().clear().type('ASD');
+        getInputBaseInput().should('have.value', '');
+        getOutputBaseInput().clear().type('ZXC');
+        getOutputBaseInput().should('have.value', '');
     });
 });
 

--- a/libs/base-converter/src/lib/components/base-converter/base-converter-component.tsx
+++ b/libs/base-converter/src/lib/components/base-converter/base-converter-component.tsx
@@ -216,8 +216,15 @@ export const BaseConverterComponent: FC<P> = ({ onConversionChange }) => {
                     <TextField
                         data-test="bconv-input-base"
                         className={classes.inputBase}
+                        type={'number'}
                         variant={'outlined'}
                         size={'small'}
+                        InputProps={{
+                            inputProps: {
+                                min: BaseDigits.MIN_BASE,
+                                max: BaseDigits.MAX_BASE
+                            }
+                        }}
                         name={'inputBase'}
                         id={'inputBase'}
                         label={t('baseConverter.inputBase')}
@@ -241,8 +248,15 @@ export const BaseConverterComponent: FC<P> = ({ onConversionChange }) => {
                         className={classes.outputBase}
                         size={'small'}
                         variant={'outlined'}
+                        type={'number'}
                         name={'outputBase'}
                         id={'outputBase'}
+                        InputProps={{
+                            inputProps: {
+                                min: BaseDigits.MIN_BASE,
+                                max: BaseDigits.MAX_BASE
+                            }
+                        }}
                         label={t('baseConverter.outputBase')}
                         error={!!form.errors.outputBase}
                         helperText={form.errors.outputBase}

--- a/libs/calc-arithmetic/src/lib/positional/base-digits.spec.ts
+++ b/libs/calc-arithmetic/src/lib/positional/base-digits.spec.ts
@@ -110,6 +110,56 @@ describe('base-digits', () => {
         });
     });
 
+    describe('#isValidBase', () => {
+        it('returns false when number is not a integer', () => {
+            // given
+            const base = 12.5;
+
+            // when
+            const result = BaseDigits.isValidBase(base);
+
+            // then
+            const expected = false;
+            expect(result).toEqual(expected);
+        });
+
+        it('returns false when number is smaller than MIN_BASE', () => {
+            // given
+            const base = 1;
+
+            // when
+            const result = BaseDigits.isValidBase(base);
+
+            // then
+            const expected = false;
+            expect(result).toEqual(expected);
+        });
+
+        it('returns false when number is greater than MAX_BASE', () => {
+            // given
+            const base = 100;
+
+            // when
+            const result = BaseDigits.isValidBase(base);
+
+            // then
+            const expected = false;
+            expect(result).toEqual(expected);
+        });
+
+        it('returns false when number is an integer between MIN_BASE and MAX_BASE inclusive', () => {
+            // given
+            const base = 16;
+
+            // when
+            const result = BaseDigits.isValidBase(base);
+
+            // then
+            const expected = true;
+            expect(result).toEqual(expected);
+        });
+    });
+
     describe('#getAllPossibleBasesForAssociateConversion', () => {
         it('should return all possible options for target base, that are larger than input base', () => {
             // given

--- a/libs/calc-arithmetic/src/lib/positional/base-digits.ts
+++ b/libs/calc-arithmetic/src/lib/positional/base-digits.ts
@@ -15,6 +15,7 @@ export class BaseDigits {
      * @param base
      */
     public static isValidBase(base: number): boolean {
+        if(!Number.isInteger(base)) return false;
         return base >= this.MIN_BASE && base <= this.MAX_BASE;
     }
 

--- a/libs/i18n/src/assets/en.json
+++ b/libs/i18n/src/assets/en.json
@@ -23,7 +23,7 @@
         "subtitle": "Convert between different bases with step-by-step results",
         "result": "Conversion result",
         "details": "Conversion details",
-        "wrongBase": "Base must be between {{minBase}} and {{maxBase}}",
+        "wrongBase": "Base must be an integer between {{minBase}} and {{maxBase}}",
         "wrongRepresentationStr": "Representation strings contains invalid digits for base {{base}}",
         "inputNumber": "Input number",
         "inputDecimalValue": "Input decimal value",

--- a/libs/i18n/src/assets/pl.json
+++ b/libs/i18n/src/assets/pl.json
@@ -23,7 +23,7 @@
         "subtitle": "Konweresja między podstawami ze szczegółami",
         "result": "Wynik konwersji",
         "details": "Szczegóły konwersji",
-        "wrongBase": "Podstawa musi być pomiędzy {{minBase}} i {{maxBase}}",
+        "wrongBase": "Podstawa musi być liczbą całkowitą pomiędzy {{minBase}} i {{maxBase}}",
         "wrongRepresentationStr": "Reprezentacja zawiera niepoprawne cyfry dla podstawy {{base}}",
         "inputNumber": "Liczba wejściowa",
         "inputDecimalValue": "Wartość dziesiętna wejścia",


### PR DESCRIPTION
- RC: isValidBase returned true when number was in valid
  base range but it did not check whether number is integer.
  Also, the base inputs didn't have type={'number'} set
- Fix: add check for integer values to isValidBase, change
  input types to 'number' and restrict min/max to min/max base
  
  closes #181 