### PR TITLE
Missing grid cells #240

### DIFF
--- a/libs/positional-calculator/src/lib/division/division-grid/division-meta.spec.ts
+++ b/libs/positional-calculator/src/lib/division/division-grid/division-meta.spec.ts
@@ -108,5 +108,21 @@ describe('division-meta', () => {
             const expected = 0;
             expect(meta.resultRowLeftOffset).toEqual(expected);
         });
+
+        // BUG #240
+        it('should return proper total width result has multiple leading zero digits', () => {
+            // given
+            const base = 10;
+            const dividend = fromStringDirect('121', base).result;
+            const divisor = fromStringDirect('123', base).result;
+            const result = divideDefault([dividend, divisor]);
+
+            // when
+            const meta = extractDivisionResultMeta(result);
+
+            // then
+            const expected = 9;
+            expect(meta.totalWidth).toEqual(expected);
+        });
     });
 });

--- a/libs/positional-calculator/src/lib/division/division-grid/divison-meta.ts
+++ b/libs/positional-calculator/src/lib/division/division-grid/divison-meta.ts
@@ -19,7 +19,7 @@ export function extractDivisionResultMeta(result: DivisionResult): DivisionResul
     const numDividendIntegerPartDigits = dividend.numIntegerPartDigits();
     const numDivisorDigits = divisor.numDigits();
     const numDivisorFractionPartDigits = divisor.numFractionPartDigits();
-    const numResultDigits = result.numberResult.numDigits();
+    const numResultDigits = result.resultDigits.length;
 
     const [scaledDividend, scaledDivisor] = result.operands;
     const numOperandsDigits = scaledDividend.length + scaledDivisor.length;


### PR DESCRIPTION
- RC: the grid total width is a max of result length
  and total length of operands. The result length
  was taken from .numberResult property but should
  have been taken from the length of .resultDigits
  because excess leading zeros will be stripped in
  number result, but still present in raw result
  digits
- Fix: use resultDigits.length when calculating
  total width
  
  closes #240 