### PR TITLE
Calculate should be disabled #269

### DIFF
--- a/apps/calc-web-e2e/src/integration/positional/calculator-options.spec.ts
+++ b/apps/calc-web-e2e/src/integration/positional/calculator-options.spec.ts
@@ -1,15 +1,16 @@
 import { OperationTemplate } from '@calc/positional-calculator';
-import { AlgorithmType, MultiplicationType, OperationType } from '@calc/calc-arithmetic';
+import { AlgorithmType, DivisionType, MultiplicationType, OperationType } from '@calc/calc-arithmetic';
 import {
     addOperands,
     calculatePositional,
-    checkOperationResult,
+    checkOperationResult, enterOperationParams,
     getAddOperandButton,
     getCalculateButton,
     hasProperResult,
     operationReturnsProperResult,
     selectOperation,
-    setOperationBase
+    setOperationBase,
+    setOperationPrecision
 } from '../../support/positional-calculator';
 import { getCommonTooltip } from '../../support/common';
 import { changeLanguage } from '../../support/language';
@@ -124,5 +125,43 @@ describe('Calculator options', () => {
         // proper result should be displayed without without editing inputs and clicking submit
         const expected = '-6864';
         checkOperationResult(expected);
-    })
+    });
+
+    // BUG #268
+    it('should disable calculate button when precision is not valid', () => {
+        const config: OperationTemplate<AlgorithmType> = {
+            operands: ['78', '-88'],
+            operation: OperationType.Division,
+            algorithm: DivisionType.Default,
+            base: 10,
+            precision: 10
+        };
+        enterOperationParams(config);
+        getCalculateButton().should('not.be.disabled');
+
+        setOperationPrecision(20);
+        getCalculateButton().should('be.disabled');
+
+        setOperationPrecision(10);
+        getCalculateButton().should('not.be.disabled');
+    });
+
+    // BUG #268
+    it('should disable calculate button when base is not valid', () => {
+        const config: OperationTemplate<AlgorithmType> = {
+            operands: ['78', '-88'],
+            operation: OperationType.Division,
+            algorithm: DivisionType.Default,
+            base: 10,
+            precision: 5
+        };
+        enterOperationParams(config);
+        getCalculateButton().should('not.be.disabled');
+
+        setOperationBase(1);
+        getCalculateButton().should('be.disabled');
+
+        setOperationBase(10);
+        getCalculateButton().should('not.be.disabled');
+    });
 });

--- a/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
+++ b/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
@@ -87,7 +87,6 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
     const [algorithm, setAlgorithm] = useState<OperationAlgorithm>(defaultAlgorithm || multiplicationAlgorithms[1]);
     const [operationAlgorithms, setOperationAlgorithms] = useState<OperationAlgorithm[]>(multiplicationAlgorithms);
     const [errorMessage, setErrorMessage] = useState<string>('');
-    const [submitDisabled, setSubmitDisabled] = useState(false);
     const optionsFromUrl = useUrlCalculatorOptions();
     const history = useHistory();
 
@@ -130,6 +129,7 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
     };
 
     const validatePrecision = (precision?: number): string | undefined => {
+        console.log("Validating precision", precision, isValidPrecision(precision));
         if(!precision) return undefined;
         if (!isValidPrecision(precision)) {
             return t(
@@ -145,7 +145,11 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
             precision: validatePrecision(values.precision)
         };
 
-        return clean(errors);
+        const cleaned = clean(errors);
+
+        console.log(cleaned);
+
+        return cleaned;
     };
 
     const handleSubmit = (form: FormValues) => {
@@ -189,30 +193,43 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
         setOperands((prev) => [...prev, { representation: defaultStr, valid: true, dndKey: `${Date.now()}` }]);
     };
 
-    const computeCanCalculate = () => {
-        const everyOperandValid = operands.every((op) => op.valid);
-        const { minOperands, maxOperands } = operation;
-        const allowedNumOfOperands = inRangeInclusive(operands.length, minOperands, maxOperands);
-        return everyOperandValid && allowedNumOfOperands;
-    };
-
     useEffect(() => {
-        const everyOperandValid = operands.every((op) => op.valid);
         let newMessage = '';
+
+        const precisionValid = !form.errors.precision;
+        if(!precisionValid) {
+            newMessage = t(
+                'positionalCalculator.wrongPrecision',
+                { minPrecision: DIVISION_MIN_PRECISION, maxPrecision: DIVISION_MAX_PRECISION }
+            );
+        }
+
+        const everyOperandValid = operands.every((op) => op.valid);
         if (!everyOperandValid) newMessage = t('positionalCalculator.operandsNotValid');
 
         const { minOperands, maxOperands } = operation;
-
         const allowedNumOfOperands = inRangeInclusive(operands.length, minOperands, maxOperands);
         if (!allowedNumOfOperands) newMessage = t('positionalCalculator.wrongOperandsNum', {
             minOperands,
             maxOperands
         });
 
-        const canCalculate = computeCanCalculate();
+        const baseValid = !form.errors.base;
+        if(!baseValid) {
+            newMessage = t(
+                'baseConverter.wrongBase',
+                { minBase: BaseDigits.MIN_BASE, maxBase: BaseDigits.MAX_BASE }
+            );
+        }
+
+        const canCalculate = baseValid
+            && everyOperandValid
+            && allowedNumOfOperands
+            && precisionValid;
+
         setErrorMessage(newMessage);
         setCanCalculate(canCalculate);
-    }, [operands, operation, t, form.values.base]);
+    }, [operands, operation, t, form.errors]);
 
     useEffect(() => {
         onOperationChange(operation.type);
@@ -244,11 +261,6 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
         const canAdd = operation.maxOperands > operands.length;
         setCanAddOperand(canAdd);
     }, [operands, operation]);
-
-    useEffect(() => {
-        const disabled = operands.length < 1 || !canCalculate;
-        setSubmitDisabled(disabled);
-    }, [form.isValid, operands, canCalculate]);
 
     return (
         <Root>
@@ -301,7 +313,7 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
                     />
                 }
                 <div className={classes.growSpacer}/>
-                <Tooltip title={errorMessage}>
+                <Tooltip title={errorMessage} placement={'top'}>
                     <span>
                          <Button
                              data-testid="submit"
@@ -310,7 +322,7 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
                              color={'info'}
                              variant={'contained'}
                              className={classes.addOperand}
-                             disabled={submitDisabled}
+                             disabled={!canCalculate}
                          >
                             {t('positionalCalculator.calculate')}
                         </Button>

--- a/libs/positional-calculator/src/lib/validators/validators.ts
+++ b/libs/positional-calculator/src/lib/validators/validators.ts
@@ -1,4 +1,5 @@
 import {
+    BaseDigits,
     fromStringDirect,
     isValidComplementOrRepresentationStr,
     OperandInputValue,


### PR DESCRIPTION
- RC: submitDisabled was not taking into account
  the form.isValid option, not sure if it was
  working earlier, or it was always broken,
  but there were some missing e2e coverage
- FIX: remove submitDisabled, use only
  negation of canCalculate, add missing e2e
  for checking whether calculate is disabled
  
  closes #269 