### PR TITLE
Unhandled error when adding operand #269

### DIFF
--- a/apps/calc-web-e2e/src/integration/positional/calculator-options.spec.ts
+++ b/apps/calc-web-e2e/src/integration/positional/calculator-options.spec.ts
@@ -1,13 +1,14 @@
 import { OperationTemplate } from '@calc/positional-calculator';
 import { AlgorithmType, DivisionType, MultiplicationType, OperationType } from '@calc/calc-arithmetic';
 import {
+    addOperand,
     addOperands,
     calculatePositional,
     checkOperationResult, enterOperationParams,
     getAddOperandButton,
     getCalculateButton,
     hasProperResult,
-    operationReturnsProperResult,
+    operationReturnsProperResult, selectAlgorithm,
     selectOperation,
     setOperationBase,
     setOperationPrecision
@@ -162,6 +163,34 @@ describe('Calculator options', () => {
         getCalculateButton().should('be.disabled');
 
         setOperationBase(10);
+        getCalculateButton().should('not.be.disabled');
+    });
+
+    // BUG #269
+    it('should not throw any errors when add operand is pressed and base is invalid', () => {
+        // set valid base and add some operand
+        setOperationBase(10);
+        addOperands(['25']);
+
+        // change base to invalid
+        setOperationBase(1);
+        addOperand('20', 1);
+        getCalculateButton().should('be.disabled');
+
+        // change base back to valid
+        setOperationBase(10);
+        getCalculateButton().should('not.be.disabled');
+
+        // change bases and check whether operands are valid
+        setOperationBase(2);
+        getCalculateButton().should('be.disabled');
+        setOperationBase(3);
+        getCalculateButton().should('be.disabled');
+        setOperationBase(4);
+        getCalculateButton().should('be.disabled');
+        setOperationBase(5);
+        getCalculateButton().should('be.disabled');
+        setOperationBase(6);
         getCalculateButton().should('not.be.disabled');
     });
 });

--- a/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
+++ b/libs/positional-calculator/src/lib/calculator-options/calculator-options.tsx
@@ -1,7 +1,9 @@
 import React, { FC, useEffect, useState } from 'react';
 import { ExtendedSelect, FormErrors } from '@calc/common-ui';
 import {
-    BaseDigits, DIVISION_MAX_PRECISION, DIVISION_MIN_PRECISION,
+    BaseDigits,
+    DIVISION_MAX_PRECISION,
+    DIVISION_MIN_PRECISION,
     isValidPrecision,
     OperandInputValue,
     Operation,
@@ -129,7 +131,6 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
     };
 
     const validatePrecision = (precision?: number): string | undefined => {
-        console.log("Validating precision", precision, isValidPrecision(precision));
         if(!precision) return undefined;
         if (!isValidPrecision(precision)) {
             return t(
@@ -145,11 +146,7 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
             precision: validatePrecision(values.precision)
         };
 
-        const cleaned = clean(errors);
-
-        console.log(cleaned);
-
-        return cleaned;
+        return clean(errors);
     };
 
     const handleSubmit = (form: FormValues) => {
@@ -189,7 +186,8 @@ export const CalculatorOptions: FC<P> = ({ onSubmit, onOperationChange, defaultO
     };
 
     const handleAdd = () => {
-        const defaultStr = BaseDigits.getRepresentation(0, form.values.base);
+        const base = form.isValid ? form.values.base : 10;
+        const defaultStr = BaseDigits.getRepresentation(0, base);
         setOperands((prev) => [...prev, { representation: defaultStr, valid: true, dndKey: `${Date.now()}` }]);
     };
 

--- a/libs/positional-calculator/src/lib/core/calculate.ts
+++ b/libs/positional-calculator/src/lib/core/calculate.ts
@@ -168,7 +168,6 @@ function handleMultiply(
 function handleDivide(params: OperationParams): GridResult<DivisionResult> {
     switch (params.algorithm) {
         case DivisionType.Default: {
-            console.log("divvying up", params.precision)
             const result = divideDefault(params.operands, params.precision);
             const grid = buildDivisionGrid(result);
             return {

--- a/libs/positional-calculator/src/lib/validators/validators.ts
+++ b/libs/positional-calculator/src/lib/validators/validators.ts
@@ -24,6 +24,7 @@ export function isDivisorZero(input: OperandInputValue): TranslationErrorMessage
 
 export function representationValidator(input: OperandInputValue): TranslationErrorMessage | undefined {
     const { representation, base } = input;
+    if(!BaseDigits.isValidBase(base)) return;
     if (!isValidComplementOrRepresentationStr(representation, base)) {
         return {
             key: 'baseConverter.wrongRepresentationStr',


### PR DESCRIPTION
- RC: when base is invalid, add operand button
  is not disabled, and after adding operand
  validators will fail, because they assume base
  is always valid
- Fix: add fallback base when base is invalid
  when adding operand, add early return from
  representation validator when base is invalid
  
Actually  closes #269 